### PR TITLE
feat: add alternative text markdown container

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,11 @@ Document title used for `<title>` and `<nav>`
 Set to `false` to hide document from navigation menu.
 Default `true`.
 
+#### `include`
+
+Set to `false` to not write the document to file or include as a page.
+Default `true`.
+
 ### Inline tags
 
 #### `{@link ...}`

--- a/cypress/e2e/alt-container.cy.ts
+++ b/cypress/e2e/alt-container.cy.ts
@@ -1,0 +1,17 @@
+beforeEach(() => {
+    cy.visit("/markdown/custom-containers.html");
+});
+
+it("should render alternative text if file is found", () => {
+    cy.get("#content").contains(
+        "p",
+        "This is an alternative text from another markdown file.",
+    );
+});
+
+it("should render default text if file is not found", () => {
+    cy.get("#content").contains(
+        "p",
+        "This text will be rendered if the file is not found.",
+    );
+});

--- a/docs/markdown/custom-containers.md
+++ b/docs/markdown/custom-containers.md
@@ -1,0 +1,77 @@
+---
+title: Custom containers
+layout: content-with-menu
+---
+
+## Alternative text
+
+The `alt` container is used to provide an alternative text from another markdown file to replace a default text (or add text if no default text is added to the container).
+
+Can be used to simplify the process of serving different documentation snippets in cases where the repository is duplicated to another environment with a different target audience.
+
+### Usage
+
+To define a file with content you want to use as alternative text, insert its filename after the `alt` keyword.
+If this file should only be used to provide an alternative text and not be output as a page, use `include: false` in the frontmatter of the alternative text.
+Using a default text is optional. If the container's content is empty, nothing will be rendered if the file is not found.
+
+```md
+:::alt my-alternative-text-file
+This text will be rendered if the file is not found.
+:::
+```
+
+**my-alternative-text-file.md**:
+
+```md
+---
+include: false
+---
+
+This is an alternative text from another markdown file.
+```
+
+**Rendered alternative text if file is found**:
+
+:::alt my-alternative-text-file
+This text will be rendered if the file is not found.
+:::
+
+**Rendered default text if file is not found**:
+
+:::alt my-alternative-text-file-not-found
+This text will be rendered if the file is not found.
+:::
+
+### Configuration
+
+In order for the alternative text to be rendered, the file containing the alternative text need to be included in `sourceFiles` using `frontMatterFileReader`.
+
+Alt files may be included by being located in the documentation file structure (such as right next to the documentation file pointing to it).
+If the alt files are located in a seperate folder or in an external package you will need to provide its path in `sourceFiles` as well.
+
+```mjs
+// docs.config.mjs
+export default {
+    sourceFiles: [
+        // Files used to generate documentation (alt files will also be included if located here)
+        {
+            include: "docs/**/*.md",
+            basePath: "./docs/",
+            fileReader: frontMatterFileReader,
+        },
+        // Alt files from other folder
+        {
+            include: "my-alt-texts/**/*.md",
+            basePath: "./my-alt-texts/",
+            fileReader: frontMatterFileReader,
+        },
+        // Alt files from external package `@my-awesome-alt-texts`
+        {
+            include: "node_modules/@my-awesome-alt-texts/dist/**/*.md",
+            basePath: "./node_modules/@my-awesome-alt-texts/dist",
+            fileReader: frontMatterFileReader,
+        },
+    ],
+};
+```

--- a/docs/markdown/my-alternative-text-file.md
+++ b/docs/markdown/my-alternative-text-file.md
@@ -1,0 +1,5 @@
+---
+include: false
+---
+
+This is an alternative text from another markdown file.

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -9,6 +9,7 @@ index.html
 live-example/example.html
 live-example/index.html
 markdown/code-preview.html
+markdown/custom-containers.html
 markdown/index.html
 navigation/child-page-1.html
 navigation/child-page-2.html

--- a/src/document.ts
+++ b/src/document.ts
@@ -16,6 +16,9 @@ export interface DocumentAttributes {
     /** visible in navigation */
     visible?: boolean;
 
+    /** if should write to file and make available as a page */
+    include?: boolean;
+
     /** component(s) this page corresponds to */
     component?: string | string[];
 

--- a/src/file-reader/front-matter-file-reader.ts
+++ b/src/file-reader/front-matter-file-reader.ts
@@ -79,6 +79,7 @@ export function parseFile(
     const name = attributes.name ? attributes.name : parsed.name;
     const urlpath = parsed.dir;
     const outline = getDocumentOutline(blocks.body, "markdown");
+    const include = attributes.include ?? true;
     return {
         id: `fs:${filePath.replace(/\\/g, "/")}`,
         name,
@@ -105,7 +106,7 @@ export function parseFile(
                 : `./${normalizePath(urlpath)}`,
             name: filename,
             fullPath: normalizePath(filePath),
-            outputName: `${filename}.html`,
+            outputName: include ? `${filename}.html` : false,
         },
     };
 }

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -188,6 +188,13 @@ exports[`smoketest 1`] = `
         },
         {
           "external": false,
+          "id": "fs:docs/markdown/custom-containers.md",
+          "path": "./markdown/custom-containers.html",
+          "sortorder": Infinity,
+          "title": "Custom containers",
+        },
+        {
+          "external": false,
           "id": "fs:docs/markdown/index.md",
           "path": "./markdown/",
           "sortorder": Infinity,

--- a/src/render/markdown/include.ts
+++ b/src/render/markdown/include.ts
@@ -176,6 +176,17 @@ export function include(
                 const content = md.render(doc.body, env);
                 return /* HTML */ ` <div>${content}</div> `;
             },
+            alt(tokens: MarkdownIt.Token[], index: number) {
+                const token = tokens[index];
+                const needle = token.info.split(" ")[1];
+                const doc = findDocument(docs, needle);
+
+                if (doc && doc.format === "markdown") {
+                    return md.render(doc.body, env);
+                }
+
+                return md.render(token.content, env);
+            },
         });
     };
 }


### PR DESCRIPTION
Lägger till att kunna ha en alternativ text från annan markdown fil. Förhoppningsvis är implementationen åt rätt håll.

Tar gärna feedback kring vad den ska heta. Har satt det som `alt`, som i alternative text. Andra tankar var `amend` som i amend text.

Kollade även upp hur dessa `:::` block benämns och kom fram till "custom container" genom att googla runt. Om ni har bättre koll tar jag gärna input där.

Frågetecken:
- Behöver vi felhantering i `alt`?
- Finns det nåt vettigt sätt att skriva tester för att säkerställa att `alt` fungerar?

Noterar också att vi inte verkar ha nån direkt dokumentation för `api` container, om inte jag har missat nåt.
Har inte åtgärdat det i denna PR, men bör antagligen läggas till inom snar framtid då det nu finns sida för dessa.
