### PR TITLE
docs: link styling (refs SFKUI-6446)

### DIFF
--- a/src/style/core.scss
+++ b/src/style/core.scss
@@ -87,6 +87,23 @@ h1 code {
     font-weight: 400;
 }
 
+#content a:not(.code-preview a) {
+    color: var(--docs-text-color-default);
+}
+
+#content a:not(.code-preview a, h2 a, h3 a, h4 a, h5 a) {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    color: var(--f-text-color-link);
+    text-decoration-color: var(--docs-text-color-link);
+    text-underline-offset: 0.15rem;
+}
+
+#content a:hover:not(.code-preview a, h2 a, h3 a, h4 a, h5 a) {
+    color: var(--f-text-color-default);
+    text-decoration-color: var(--docs-text-link-hover);
+}
+
 .layout-wrapper {
     font-family: var(--docs-font-family);
     background: #fff;

--- a/src/style/css-variables.mjs
+++ b/src/style/css-variables.mjs
@@ -22,6 +22,16 @@ export default {
                 type: "color",
                 value: "#5f6165",
             },
+            "text-color-link": {
+                description: "Link text color.",
+                type: "color",
+                value: "#4a52b6",
+            },
+            "text-color-link-hover": {
+                description: "Link text color.",
+                type: "color",
+                value: "#1b1e23",
+            },
         },
     },
 


### PR DESCRIPTION
Styling för länkar -- vad jag försöker göra här är att stajla länkar i innehållet, men inte de som är rubriker, eller i menyer etc. 
se bild nedan
![image](https://github.com/Forsakringskassan/docs-generator/assets/168091715/c5ff8629-662e-4a8d-9442-82ab28df60e1)


+ ändringar i package-lock.jason så den hänvisar till npmjs.org istället för npmjs.com