### PR TITLE
fix: responsive table of contents

### DIFF
--- a/src/runtime/breakpoints.ts
+++ b/src/runtime/breakpoints.ts
@@ -1,0 +1,5 @@
+const style = getComputedStyle(document.documentElement);
+
+export const BREAKPOINT_SMALL = style.getPropertyValue("--docs-breakpoint-sm");
+export const BREAKPOINT_MEDIUM = style.getPropertyValue("--docs-breakpoint-md");
+export const BREAKPOINT_LARGE = style.getPropertyValue("--docs-breakpoint-lg");

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -1,4 +1,4 @@
-import { tableOfContents } from "./table-of-contents";
+import { tableOfContents, toggleTableOfContents } from "./table-of-contents";
 
 const parser = new DOMParser();
 const variableBlock = document.createElement("style");
@@ -108,6 +108,7 @@ async function replaceContent(href: string): Promise<void> {
     if (toc) {
         const headings = document.querySelectorAll("#content h2");
         tableOfContents(toc, headings);
+        toggleTableOfContents();
     }
 }
 

--- a/src/runtime/table-of-contents.ts
+++ b/src/runtime/table-of-contents.ts
@@ -1,4 +1,5 @@
 import { onContentReady } from "./on-content-ready";
+import { BREAKPOINT_LARGE } from "./breakpoints";
 
 export function tableOfContents(
     toc: Element,
@@ -41,3 +42,26 @@ onContentReady(() => {
 
     tableOfContents(toc, headings);
 });
+
+const tableOfContentsQuery = window.matchMedia(
+    `(min-width: ${BREAKPOINT_LARGE})`,
+);
+tableOfContentsQuery.addEventListener("change", toggleTableOfContents);
+
+// Set initial state of toc on page load.
+toggleTableOfContents();
+
+export function toggleTableOfContents(): void {
+    const toc = document.querySelector("#outline");
+    if (!toc) {
+        return;
+    }
+
+    const { matches } = tableOfContentsQuery;
+    const isOpen = toc.hasAttribute("open");
+    if (matches && !isOpen) {
+        toc.setAttribute("open", "");
+    } else if (!matches && isOpen) {
+        toc.removeAttribute("open");
+    }
+}

--- a/src/style/_breakpoints.scss
+++ b/src/style/_breakpoints.scss
@@ -1,3 +1,9 @@
 $breakpoint-sm: 640px;
 $breakpoint-md: 1024px;
 $breakpoint-lg: 1280px;
+
+:root {
+    --docs-breakpoint-sm: #{$breakpoint-sm};
+    --docs-breakpoint-md: #{$breakpoint-md};
+    --docs-breakpoint-lg: #{$breakpoint-lg};
+}

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -39,7 +39,7 @@ main {
             "sidenav content" 1fr
             / min-content 1fr;
 
-        @media screen and (width >= #{bp.$breakpoint-md}) {
+        @media screen and (width >= #{bp.$breakpoint-lg}) {
             grid-template:
                 "sidenav title aside" auto
                 "sidenav content aside" 1fr

--- a/src/style/_outline.scss
+++ b/src/style/_outline.scss
@@ -11,17 +11,47 @@ $outline-active-background: $fk-black-15;
 
 #outline {
     margin-bottom: 1rem;
-    display: none;
-    position: sticky;
-    top: 1rem;
-    padding-right: 1rem;
-    max-height: calc(100vh - 2rem);
-    overflow-y: auto;
-    max-width: 15rem;
-    scrollbar-width: thin;
+
+    summary {
+        display: flex;
+    }
 
     @media (width >= #{bp.$breakpoint-lg}) {
-        display: block;
+        position: sticky;
+        top: 1rem;
+        padding: 0.25rem 1rem 0.25rem 0.25rem;
+        overflow-y: auto;
+        max-height: calc(100vh - 2rem);
+        max-width: 15rem;
+        scrollbar-width: thin;
+
+        summary {
+            pointer-events: none;
+            cursor: text;
+        }
+    }
+
+    @media (width < #{bp.$breakpoint-lg}) {
+        summary {
+            width: min-content;
+            cursor: pointer;
+
+            &::after {
+                content: url("data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KPHBhdGggZD0iTTQ2Ny42NTggMTk2LjkxM0wyODMuNjU2IDM3Mi45MDdDMjc1LjkyMiAzODAuMzEzIDI2NS45NTMgMzg0IDI1NiAzODRDMjQ2LjA0NyAzODQgMjM2LjA3OCAzODAuMzEzIDIyOC4zNDQgMzcyLjkwN0w0NC4zNDIgMTk2LjkxM0MyOC4zODkgMTgxLjYzMyAyNy44MjYgMTU2LjMyMSA0My4wOTIgMTQwLjM1M0M1OC4zNzMgMTI0LjM1NCA4My42ODYgMTIzLjg1NCA5OS42NTUgMTM5LjEwM0wyNTYgMjg4LjY2TDQxMi4zNDUgMTM5LjEwM0M0MjguMzE0IDEyMy44MjIgNDUzLjYyNyAxMjQuMzg1IDQ2OC45MDggMTQwLjM1M0M0ODQuMTc0IDE1Ni4zMjEgNDgzLjYxMSAxODEuNjMzIDQ2Ny42NTggMTk2LjkxM1oiIGZpbGw9ImN1cnJlbnRDb2xvciIvPgo8L3N2Zz4K");
+                transform: translateY(3px);
+                transition: all 200ms cubic-bezier(0.46, 0.03, 0.52, 0.96) 0s;
+                margin-left: 0.5rem;
+                width: 1rem;
+                height: 1rem;
+                display: inline;
+            }
+        }
+
+        &[open] > summary::after {
+            content: url("data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KPHBhdGggZD0iTTQ2Ny42NTggMTk2LjkxM0wyODMuNjU2IDM3Mi45MDdDMjc1LjkyMiAzODAuMzEzIDI2NS45NTMgMzg0IDI1NiAzODRDMjQ2LjA0NyAzODQgMjM2LjA3OCAzODAuMzEzIDIyOC4zNDQgMzcyLjkwN0w0NC4zNDIgMTk2LjkxM0MyOC4zODkgMTgxLjYzMyAyNy44MjYgMTU2LjMyMSA0My4wOTIgMTQwLjM1M0M1OC4zNzMgMTI0LjM1NCA4My42ODYgMTIzLjg1NCA5OS42NTUgMTM5LjEwM0wyNTYgMjg4LjY2TDQxMi4zNDUgMTM5LjEwM0M0MjguMzE0IDEyMy44MjIgNDUzLjYyNyAxMjQuMzg1IDQ2OC45MDggMTQwLjM1M0M0ODQuMTc0IDE1Ni4zMjEgNDgzLjYxMSAxODEuNjMzIDQ2Ny42NTggMTk2LjkxM1oiIGZpbGw9ImN1cnJlbnRDb2xvciIvPgo8L3N2Zz4K");
+            transform: rotate(180deg) translateY(-5px);
+            transition: all 200ms cubic-bezier(0.46, 0.03, 0.52, 0.96) 0s;
+        }
     }
 
     &::-webkit-scrollbar {

--- a/templates/base.template.html
+++ b/templates/base.template.html
@@ -88,6 +88,8 @@
                         {%- block aside %}
                         {%- endblock %}
 
+
+                        {% if doc.outline | length %}
                         <details id="outline">
                             <summary class="outline__heading">Innehåll</summary>
                             <ul>
@@ -96,6 +98,7 @@
                                 {% endfor %}
                             </ul>
                         </details>
+                        {% endif %}
                     </div>
                     {% endif %}
 

--- a/templates/base.template.html
+++ b/templates/base.template.html
@@ -88,14 +88,14 @@
                         {%- block aside %}
                         {%- endblock %}
 
-                        <div id="outline">
-                            <h2 class="outline__heading">Innehåll</h2>
+                        <details id="outline">
+                            <summary class="outline__heading">Innehåll</summary>
                             <ul>
                                 {% for heading in doc.outline %}
                                 <li><a href="#{{ heading.anchor }}">{{ heading.title | escape }}</a></li>
                                 {% endfor %}
                             </ul>
-                        </div>
+                        </details>
                     </div>
                     {% endif %}
 


### PR DESCRIPTION
- `fix: do not render empty outline`

Sidor med `layout: component` men inga headings renderar fortfarande en tom outline med endast rubriken "Innehåll". Ändrar så att den inte renderas alls om inga headings finns.

- `fix: responsive table of contents`

Ändrar så att innehållsförteckningen fortfarande visas när aside staplas med övrigt innehåll.
Beteendet är satt så att outline automatiskt sätts som öppen när den ändras till stor storlek, och stängd i "mobil" storlek.

Då mycket av `details` elementet ligger i shadow var det svårt att ändra hur den fungerar/ser ut. Fick därav mecka lite i js för att få ihop det med breakpoints. Gör ont i att behöva duplicera breakpoint värdet så testar att fånga från css variables istället. Men tar gärna förslag på lösningar.

Efter:
![outline_large](https://github.com/user-attachments/assets/7c5811df-76a0-4ca8-9a39-fee57422245d)
![outline_small_closed](https://github.com/user-attachments/assets/263c0edd-4659-4c2e-82d1-f30bc12893b4)
![outline_small_open](https://github.com/user-attachments/assets/a07650ff-c372-42f0-bd63-a56f16a791c7)


