### PR TITLE
feat(api): `compileScript` and `compileStyle` accepts URL parameter

### DIFF
--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -82,7 +82,7 @@ class Generator_2 {
     // (undocumented)
     build(sourceFiles: SourceFiles[]): Promise<string[]>;
     // (undocumented)
-    compileScript(name: string, src: string | URL | Array<string | URL>, options?: Partial<CompileOptions>): void;
+    compileScript(name: string, src: string | URL, options?: Partial<CompileOptions>): void;
     // (undocumented)
     compileStyle(name: string, src: string | URL, options?: Partial<CompileOptions>): void;
     // (undocumented)

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -82,9 +82,9 @@ class Generator_2 {
     // (undocumented)
     build(sourceFiles: SourceFiles[]): Promise<string[]>;
     // (undocumented)
-    compileScript(name: string, src: string | string[], options?: Partial<CompileOptions>): void;
+    compileScript(name: string, src: string | URL | Array<string | URL>, options?: Partial<CompileOptions>): void;
     // (undocumented)
-    compileStyle(name: string, src: string, options?: Partial<CompileOptions>): void;
+    compileStyle(name: string, src: string | URL, options?: Partial<CompileOptions>): void;
     // (undocumented)
     copyResource(dst: string, src: string): void;
     manifest(sourceFiles: SourceFiles[]): Promise<Manifest>;

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { type BuildOptions, build as esbuild } from "esbuild";
 import { getFingerprint, getIntegrity } from "../utils";
 import { AssetInfo } from "./asset-info";
@@ -12,13 +13,17 @@ function toArray<T>(value: T | T[]): T[] {
     }
 }
 
+function toFilePath(value: string | URL): string {
+    return value instanceof URL ? fileURLToPath(value) : value;
+}
+
 /**
  * @internal
  */
 export async function compileScript(
     assetFolder: string,
     name: string,
-    src: string | string[],
+    src: string | URL | Array<string | URL>,
     options?: BuildOptions,
 ): Promise<AssetInfo> {
     const iconLib = process.env.DOCS_ICON_LIB ?? "@fkui/icon-lib-default";
@@ -26,7 +31,7 @@ export async function compileScript(
     try {
         const outfile = path.join("temp", `asset-${name}.js`);
         await esbuild({
-            entryPoints: toArray(src),
+            entryPoints: toArray(src).map(toFilePath),
             outfile,
             bundle: true,
             format: "iife",

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -5,33 +5,22 @@ import { type BuildOptions, build as esbuild } from "esbuild";
 import { getFingerprint, getIntegrity } from "../utils";
 import { AssetInfo } from "./asset-info";
 
-function toArray<T>(value: T | T[]): T[] {
-    if (Array.isArray(value)) {
-        return value;
-    } else {
-        return [value];
-    }
-}
-
-function toFilePath(value: string | URL): string {
-    return value instanceof URL ? fileURLToPath(value) : value;
-}
-
 /**
  * @internal
  */
 export async function compileScript(
     assetFolder: string,
     name: string,
-    src: string | URL | Array<string | URL>,
+    src: string | URL,
     options?: BuildOptions,
 ): Promise<AssetInfo> {
     const iconLib = process.env.DOCS_ICON_LIB ?? "@fkui/icon-lib-default";
 
     try {
+        const entryPoints = [src instanceof URL ? fileURLToPath(src) : src];
         const outfile = path.join("temp", `asset-${name}.js`);
         await esbuild({
-            entryPoints: toArray(src).map(toFilePath),
+            entryPoints,
             outfile,
             bundle: true,
             format: "iife",

--- a/src/assets/compile-style.ts
+++ b/src/assets/compile-style.ts
@@ -10,7 +10,7 @@ import { AssetInfo } from "./asset-info";
 export async function compileStyle(
     assetFolder: string,
     name: string,
-    src: string,
+    src: string | URL,
 ): Promise<AssetInfo> {
     try {
         const outfile = path.join("temp", `asset-${name}.css`);

--- a/src/assets/css-asset-processor.ts
+++ b/src/assets/css-asset-processor.ts
@@ -8,7 +8,7 @@ import { compileStyle } from "./compile-style";
  */
 export interface CSSAsset {
     name: string;
-    src: string;
+    src: string | URL;
     options: CompileOptions;
 }
 

--- a/src/assets/js-asset-processor.ts
+++ b/src/assets/js-asset-processor.ts
@@ -8,7 +8,7 @@ import { compileScript } from "./compile-script";
  */
 export interface JSAsset {
     name: string;
-    src: string | URL | Array<string | URL>;
+    src: string | URL;
     options: CompileOptions;
 }
 

--- a/src/assets/js-asset-processor.ts
+++ b/src/assets/js-asset-processor.ts
@@ -8,7 +8,7 @@ import { compileScript } from "./compile-script";
  */
 export interface JSAsset {
     name: string;
-    src: string | string[];
+    src: string | URL | Array<string | URL>;
     options: CompileOptions;
 }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import fse from "fs-extra";
 import {
     type CompileOptions,
@@ -269,14 +268,14 @@ export class Generator {
         this.sourceFiles = [];
 
         const bootstrapUrl = new URL("runtime-bootstrap.js", import.meta.url);
-        this.compileScript("bootstrap", fileURLToPath(bootstrapUrl), {
+        this.compileScript("bootstrap", bootstrapUrl, {
             appendTo: "head",
         });
     }
 
     public compileScript(
         name: string,
-        src: string | string[],
+        src: string | URL | Array<string | URL>,
         options?: Partial<CompileOptions>,
     ): void {
         this.scripts.push({
@@ -292,7 +291,7 @@ export class Generator {
 
     public compileStyle(
         name: string,
-        src: string,
+        src: string | URL,
         options?: Partial<CompileOptions>,
     ): void {
         this.styles.push({

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -275,7 +275,7 @@ export class Generator {
 
     public compileScript(
         name: string,
-        src: string | URL | Array<string | URL>,
+        src: string | URL,
         options?: Partial<CompileOptions>,
     ): void {
         this.scripts.push({


### PR DESCRIPTION
Extracted from #48.

This is useful when dealing with ESM constructs such as having to use `import.meta.url`, e.g:

```diff
         const bootstrapUrl = new URL("runtime-bootstrap.js", import.meta.url);
-        this.compileScript("bootstrap", fileURLToPath(bootstrapUrl), {
+        this.compileScript("bootstrap", bootstrapUrl, {
             appendTo: "head",
         });
```

Just a quality of life thing :)