### PR TITLE
fix: hide seconds from buildinfo

### DIFF
--- a/src/processors/version-processor.ts
+++ b/src/processors/version-processor.ts
@@ -129,7 +129,10 @@ function getBuildDatetime(): { date: string; time: string } {
     const date = new Date();
     return {
         date: date.toLocaleDateString("sv-SE"),
-        time: date.toLocaleTimeString("sv-SE"),
+        time: date.toLocaleTimeString("sv-SE", {
+            hour: "2-digit",
+            minute: "2-digit",
+        }),
     };
 }
 


### PR DESCRIPTION
Extracted from https://github.com/Forsakringskassan/docs-generator/pull/48.

Only display hour:minute in the buildinfo. It seems excessive and unnecessary to include.

Before:

![docs-generator-seconds](https://github.com/user-attachments/assets/c21519c7-77b3-43f1-9647-5f2ac7e7fb04)

After:

![docs-generator-no-seconds](https://github.com/user-attachments/assets/8ccb0840-518e-49e5-90b6-a7515f008107)
