### PR TITLE
feat: processors may contain optional runtime scripts

### DIFF
--- a/docs/processors/index.md
+++ b/docs/processors/index.md
@@ -15,6 +15,7 @@ export interface ProcessorHandler {
     after?: ProcessorStage;
     name: string;
     enabled?: boolean;
+    runtime?: ProcessorRuntime[];
     handler(
         context: ProcessorContext,
     ): void | string[] | Promise<void> | Promise<string[]>;
@@ -28,6 +29,28 @@ processor-stage.ts
 ```
 
 The `handler` callback performs the actual work.
+
+> Note: when bundling processors in `@forsakringskassan/docs-generator` remember to add your processor to `src/available-processors.ts`!
+
+### Runtime scripts
+
+If the processor needs a runtime script to be executed in the client browser use the `runtime` property to set one or more filenames.
+
+```ts
+export function myProcessor(): Processor {
+    return {
+        name: "awesome-processor",
+        runtime: [{ src: "src/runtime/awesome-processor.ts" }],
+    };
+}
+```
+
+Scripts from enabled processors will be bundled into a bundle `processors` added before the `</body>` tag.
+Scripts from unused processors will not be included.
+
+> Note: unless you are bundling your processor in
+> `@forsakringskassan/docs-generator` it is up to you to make sure the script is
+> properly compiled before building the documentation.
 
 ### Navigation
 

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -82,7 +82,7 @@ class Generator_2 {
     // (undocumented)
     build(sourceFiles: SourceFiles[]): Promise<string[]>;
     // (undocumented)
-    compileScript(name: string, src: string | URL | Array<string | URL>, options?: Partial<CompileOptions>): void;
+    compileScript(name: string, src: string | URL, options?: Partial<CompileOptions>): void;
     // (undocumented)
     compileStyle(name: string, src: string | URL, options?: Partial<CompileOptions>): void;
     // (undocumented)

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -14,6 +14,9 @@ export type AttributeValue = string | number | boolean | null | {
     [key: string]: AttributeValue;
 };
 
+// @internal
+export const availableProcessors: Processor[];
+
 // @public (undocumented)
 export interface CompileOptions {
     appendTo: "none" | "head" | "body";
@@ -134,7 +137,7 @@ export interface Manifest {
 }
 
 // @public
-export function manifestProcessor(options: ManifestProcessorOptions): Processor;
+export function manifestProcessor(options?: ManifestProcessorOptions): Processor;
 
 // @public
 export interface ManifestProcessorOptions {
@@ -272,6 +275,7 @@ export interface ProcessorHandler {
     handler(context: ProcessorContext): void | string[] | Promise<void> | Promise<string[]>;
     // (undocumented)
     name: string;
+    runtime?: ProcessorRuntime[];
     // (undocumented)
     stage?: ProcessorStage;
 }
@@ -285,6 +289,15 @@ export type ProcessorHook<K extends "before" | "stage" | "after"> = {
 export interface ProcessorOptions {
     enabled?: boolean;
 }
+
+// @public
+export interface ProcessorRuntime {
+    name?: string;
+    src: string;
+}
+
+// @internal
+export function processorRuntimeName(processor: Processor, runtime: ProcessorRuntime): string;
 
 // @public (undocumented)
 export type ProcessorStage = "generate-docs" | "generate-nav" | "assets" | "render";

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -82,9 +82,9 @@ class Generator_2 {
     // (undocumented)
     build(sourceFiles: SourceFiles[]): Promise<string[]>;
     // (undocumented)
-    compileScript(name: string, src: string | string[], options?: Partial<CompileOptions>): void;
+    compileScript(name: string, src: string | URL | Array<string | URL>, options?: Partial<CompileOptions>): void;
     // (undocumented)
-    compileStyle(name: string, src: string, options?: Partial<CompileOptions>): void;
+    compileStyle(name: string, src: string | URL, options?: Partial<CompileOptions>): void;
     // (undocumented)
     copyResource(dst: string, src: string): void;
     manifest(sourceFiles: SourceFiles[]): Promise<Manifest>;

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -37,6 +37,7 @@ export async function compileScript(
         const integrity = getIntegrity(content);
         const filename = `${name}-${fingerprint}.js`;
         const dst = path.join(assetFolder, filename);
+        await fs.mkdir(path.dirname(dst), { recursive: true });
         await fs.rename(outfile, dst);
         const stat = await fs.stat(dst);
         return {

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { type BuildOptions, build as esbuild } from "esbuild";
 import { getFingerprint, getIntegrity } from "../utils";
 import { AssetInfo } from "./asset-info";
@@ -12,13 +13,17 @@ function toArray<T>(value: T | T[]): T[] {
     }
 }
 
+function toFilePath(value: string | URL): string {
+    return value instanceof URL ? fileURLToPath(value) : value;
+}
+
 /**
  * @internal
  */
 export async function compileScript(
     assetFolder: string,
     name: string,
-    src: string | string[],
+    src: string | URL | Array<string | URL>,
     options?: BuildOptions,
 ): Promise<AssetInfo> {
     const iconLib = process.env.DOCS_ICON_LIB ?? "@fkui/icon-lib-default";
@@ -26,7 +31,7 @@ export async function compileScript(
     try {
         const outfile = path.join("temp", `asset-${name}.js`);
         await esbuild({
-            entryPoints: toArray(src),
+            entryPoints: toArray(src).map(toFilePath),
             outfile,
             bundle: true,
             format: "iife",

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -5,33 +5,22 @@ import { type BuildOptions, build as esbuild } from "esbuild";
 import { getFingerprint, getIntegrity } from "../utils";
 import { AssetInfo } from "./asset-info";
 
-function toArray<T>(value: T | T[]): T[] {
-    if (Array.isArray(value)) {
-        return value;
-    } else {
-        return [value];
-    }
-}
-
-function toFilePath(value: string | URL): string {
-    return value instanceof URL ? fileURLToPath(value) : value;
-}
-
 /**
  * @internal
  */
 export async function compileScript(
     assetFolder: string,
     name: string,
-    src: string | URL | Array<string | URL>,
+    src: string | URL,
     options?: BuildOptions,
 ): Promise<AssetInfo> {
     const iconLib = process.env.DOCS_ICON_LIB ?? "@fkui/icon-lib-default";
 
     try {
+        const entryPoints = [src instanceof URL ? fileURLToPath(src) : src];
         const outfile = path.join("temp", `asset-${name}.js`);
         await esbuild({
-            entryPoints: toArray(src).map(toFilePath),
+            entryPoints,
             outfile,
             bundle: true,
             format: "iife",

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -48,7 +48,8 @@ export async function compileScript(
             size: stat.size,
             type: "js",
         };
-    } catch {
-        throw new Error(`Failed to compile script "${name}"`);
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to compile script "${name}": ${reason}`);
     }
 }

--- a/src/assets/compile-style.ts
+++ b/src/assets/compile-style.ts
@@ -10,7 +10,7 @@ import { AssetInfo } from "./asset-info";
 export async function compileStyle(
     assetFolder: string,
     name: string,
-    src: string,
+    src: string | URL,
 ): Promise<AssetInfo> {
     try {
         const outfile = path.join("temp", `asset-${name}.css`);

--- a/src/assets/css-asset-processor.ts
+++ b/src/assets/css-asset-processor.ts
@@ -8,7 +8,7 @@ import { compileStyle } from "./compile-style";
  */
 export interface CSSAsset {
     name: string;
-    src: string;
+    src: string | URL;
     options: CompileOptions;
 }
 

--- a/src/assets/js-asset-processor.ts
+++ b/src/assets/js-asset-processor.ts
@@ -8,7 +8,7 @@ import { compileScript } from "./compile-script";
  */
 export interface JSAsset {
     name: string;
-    src: string | URL | Array<string | URL>;
+    src: string | URL;
     options: CompileOptions;
 }
 

--- a/src/assets/js-asset-processor.ts
+++ b/src/assets/js-asset-processor.ts
@@ -8,7 +8,7 @@ import { compileScript } from "./compile-script";
  */
 export interface JSAsset {
     name: string;
-    src: string | string[];
+    src: string | URL | Array<string | URL>;
     options: CompileOptions;
 }
 

--- a/src/available-processors.ts
+++ b/src/available-processors.ts
@@ -1,0 +1,28 @@
+import { matomoProcessor } from "./matomo";
+import {
+    cookieProcessor,
+    manifestProcessor,
+    motdProcessor,
+    selectableVersionProcessor,
+    sourceUrlProcessor,
+    themeSelectProcessor,
+    topnavProcessor,
+    versionProcessor,
+} from "./processors";
+
+/**
+ * Used by build-script to find all runtime scripts that needs compilation.
+ *
+ * @internal
+ */
+export const availableProcessors = [
+    cookieProcessor(),
+    manifestProcessor(),
+    matomoProcessor({ siteId: "", trackerUrl: "" }),
+    motdProcessor({ message: "" }),
+    selectableVersionProcessor({ name: "", version: "" }, ""),
+    sourceUrlProcessor({ urlFormat: "" }),
+    themeSelectProcessor(),
+    topnavProcessor("", ""),
+    versionProcessor({ name: "", version: "", homepage: "" }, ""),
+];

--- a/src/compile-processor-runtime.spec.ts
+++ b/src/compile-processor-runtime.spec.ts
@@ -1,0 +1,138 @@
+import { type Generator } from "./generator";
+import { compileProcessorRuntime } from "./compile-processor-runtime";
+
+const docs: Pick<Generator, "compileScript"> = {
+    compileScript() {
+        /* do nothing */
+    },
+};
+
+const compileScript = jest.spyOn(docs, "compileScript");
+
+beforeEach(() => {
+    compileScript.mockReset();
+});
+
+it("should queue runtime scripts for compilation", () => {
+    expect.assertions(2);
+    compileProcessorRuntime(docs, `file://${__filename}`, [
+        {
+            name: "foo",
+            before: "assets",
+            runtime: [{ src: "foo.js" }],
+            handler() {
+                /* do nothing */
+            },
+        },
+    ]);
+    expect(compileScript).toHaveBeenCalledTimes(1);
+    expect(compileScript).toHaveBeenCalledWith("processors/foo/foo", "foo.js", {
+        appendTo: "body",
+    });
+});
+
+it("should handle multiple scripts from same processor", () => {
+    expect.assertions(3);
+    compileProcessorRuntime(docs, `file://${__filename}`, [
+        {
+            name: "foo",
+            before: "assets",
+            runtime: [{ src: "foo.js" }, { src: "bar.js" }],
+            handler() {
+                /* do nothing */
+            },
+        },
+    ]);
+    expect(compileScript).toHaveBeenCalledTimes(2);
+    expect(compileScript).toHaveBeenCalledWith("processors/foo/foo", "foo.js", {
+        appendTo: "body",
+    });
+    expect(compileScript).toHaveBeenCalledWith("processors/foo/bar", "bar.js", {
+        appendTo: "body",
+    });
+});
+
+it("should handle multiple processors with runtime scripts", () => {
+    expect.assertions(3);
+    compileProcessorRuntime(docs, `file://${__filename}`, [
+        {
+            name: "foo",
+            before: "assets",
+            runtime: [{ src: "foo.js" }],
+            handler() {
+                /* do nothing */
+            },
+        },
+        {
+            name: "bar",
+            before: "assets",
+            runtime: [{ src: "foo.js" }],
+            handler() {
+                /* do nothing */
+            },
+        },
+    ]);
+    expect(compileScript).toHaveBeenCalledTimes(2);
+    expect(compileScript).toHaveBeenCalledWith("processors/foo/foo", "foo.js", {
+        appendTo: "body",
+    });
+    expect(compileScript).toHaveBeenCalledWith("processors/bar/foo", "foo.js", {
+        appendTo: "body",
+    });
+});
+
+it("should handle processor without runtime scripts", () => {
+    expect.assertions(1);
+    compileProcessorRuntime(docs, `file://${__filename}`, [
+        {
+            name: "foo",
+            before: "assets",
+            handler() {
+                /* do nothing */
+            },
+        },
+        {
+            name: "bar",
+            before: "assets",
+            runtime: [],
+            handler() {
+                /* do nothing */
+            },
+        },
+    ]);
+    expect(compileScript).toHaveBeenCalledTimes(0);
+});
+
+it("should not include scripts from disabled processors", () => {
+    expect.assertions(1);
+    compileProcessorRuntime(docs, `file://${__filename}`, [
+        {
+            name: "foo",
+            enabled: false,
+            before: "assets",
+            runtime: [{ src: "foo.js" }],
+            handler() {
+                /* do nothing */
+            },
+        },
+    ]);
+    expect(compileScript).toHaveBeenCalledTimes(0);
+});
+
+it("should use custom asset name if provided", () => {
+    expect.assertions(2);
+    compileProcessorRuntime(docs, `file://${__filename}`, [
+        {
+            name: "foo",
+            before: "assets",
+            runtime: [{ src: "foo.js", name: "bar" }],
+            handler() {
+                /* do nothing */
+            },
+        },
+    ]);
+    expect(compileScript).toHaveBeenCalledTimes(1);
+    expect(compileScript).toHaveBeenCalledWith("processors/foo/bar", "foo.js", {
+        appendTo: "body",
+    });
+});

--- a/src/compile-processor-runtime.ts
+++ b/src/compile-processor-runtime.ts
@@ -1,0 +1,36 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { type Generator } from "./generator";
+import { type Processor } from "./processor";
+import { processorRuntimeName } from "./processor-runtime-name";
+
+/**
+ * Queues all runtime scripts from enabled processors to be compiled.
+ *
+ * @internal
+ */
+export function compileProcessorRuntime(
+    generator: Pick<Generator, "compileScript">,
+    distDir: string,
+    processors: Processor[],
+): void {
+    for (const processor of processors) {
+        if (processor.enabled === false) {
+            continue;
+        }
+        const { runtime } = processor;
+        for (const entry of runtime ?? []) {
+            const assetName = [
+                "processors",
+                processor.name.replace(/-processor/, ""),
+                entry.name ?? path.parse(entry.src).name,
+            ].join("/");
+            const name = processorRuntimeName(processor, entry);
+            const bundled = new URL(`${name}.js`, distDir);
+            const scriptPath = existsSync(bundled) ? bundled : entry.src;
+            generator.compileScript(assetName, scriptPath, {
+                appendTo: "body",
+            });
+        }
+    }
+}

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import fse from "fs-extra";
 import {
     type CompileOptions,
@@ -269,14 +268,14 @@ export class Generator {
         this.sourceFiles = [];
 
         const bootstrapUrl = new URL("runtime-bootstrap.js", import.meta.url);
-        this.compileScript("bootstrap", fileURLToPath(bootstrapUrl), {
+        this.compileScript("bootstrap", bootstrapUrl, {
             appendTo: "head",
         });
     }
 
     public compileScript(
         name: string,
-        src: string | string[],
+        src: string | URL | Array<string | URL>,
         options?: Partial<CompileOptions>,
     ): void {
         this.scripts.push({
@@ -292,7 +291,7 @@ export class Generator {
 
     public compileStyle(
         name: string,
-        src: string,
+        src: string | URL,
         options?: Partial<CompileOptions>,
     ): void {
         this.styles.push({

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -11,6 +11,7 @@ import {
     jsAssetProcessor,
     staticResourcesProcessor,
 } from "./assets";
+import { compileProcessorRuntime } from "./compile-processor-runtime";
 import { type SourceFiles, fileReaderProcessor } from "./file-reader";
 import { nunjucksProcessor } from "./render";
 import { type Document } from "./document";
@@ -373,6 +374,8 @@ export class Generator {
             }),
             ...this.processors,
         ];
+
+        compileProcessorRuntime(this, import.meta.url, processors);
 
         const context = createContext();
         const generatedFiles = [

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -275,7 +275,7 @@ export class Generator {
 
     public compileScript(
         name: string,
-        src: string | URL | Array<string | URL>,
+        src: string | URL,
         options?: Partial<CompileOptions>,
     ): void {
         this.scripts.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { type CompileOptions, type ResourceTask } from "./assets";
+export { availableProcessors } from "./available-processors";
 export { defineSources } from "./define-sources";
 export {
     type Document,
@@ -35,6 +36,7 @@ export {
     type ProcessorHandler,
     type ProcessorHook,
     type ProcessorOptions,
+    type ProcessorRuntime,
 } from "./processor";
 export {
     type ProcessorContext,
@@ -42,6 +44,7 @@ export {
     type TemplateBlockRenderer,
     type TemplateData,
 } from "./processor-context";
+export { processorRuntimeName } from "./processor-runtime-name";
 export { type ProcessorStage } from "./processor-stage";
 export {
     type ManifestProcessorOptions,

--- a/src/processor-runtime-name.ts
+++ b/src/processor-runtime-name.ts
@@ -1,0 +1,15 @@
+import { ProcessorRuntime, type Processor } from "./processor";
+
+/**
+ * Derive default runtime script name from processor.
+ *
+ * @internal
+ */
+export function processorRuntimeName(
+    processor: Processor,
+    runtime: ProcessorRuntime,
+): string {
+    const { name } = processor;
+    const base = name.replace(/-processor/, "");
+    return `processors/${runtime.name ?? base}`;
+}

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -10,6 +10,19 @@ export interface ProcessorOptions {
 }
 
 /**
+ * Describes a runtime client script required by this processor.
+ *
+ * @public
+ */
+export interface ProcessorRuntime {
+    /** Path (from repo root) to the script entrypoint */
+    src: string;
+
+    /** Bundle name (in dist/processors) folder (default: derived from processor name) */
+    name?: string;
+}
+
+/**
  * @public
  */
 export type ProcessorHook<K extends "before" | "stage" | "after"> = {
@@ -25,6 +38,9 @@ export interface ProcessorHandler {
     after?: ProcessorStage;
     name: string;
     enabled?: boolean;
+
+    /** List of runtime client scripts required by this processor */
+    runtime?: ProcessorRuntime[];
 
     handler(
         context: ProcessorContext,

--- a/src/processors/manifest-processor.ts
+++ b/src/processors/manifest-processor.ts
@@ -40,7 +40,7 @@ function renderJSON(manifest: Manifest): string {
  * @public
  */
 export function manifestProcessor(
-    options: ManifestProcessorOptions,
+    options: ManifestProcessorOptions = {},
 ): Processor {
     const { markdown, json } = options;
     return {

--- a/src/processors/selectable-version-processor.ts
+++ b/src/processors/selectable-version-processor.ts
@@ -14,6 +14,11 @@ export function selectableVersionProcessor(
     return {
         name: "selectable-version-processor",
         after: "generate-docs",
+        runtime: [
+            {
+                src: "src/runtime/select-version.ts",
+            },
+        ],
         handler(context) {
             if (!enabled) {
                 return;

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -3,7 +3,6 @@ import "./mermaid";
 import "./navigation";
 import "./search";
 import "./table-of-contents";
-import "./select-version";
 import "./version-banner";
 import "./cookie";
 


### PR DESCRIPTION
Extracted from #48.

Lets processors include optional runtime scripts.

```ts
export function awesomeProcessor(): Processor {
    return {
        name: "awesome-processor",
        runtime: [{ src: "docs/src/awesome.js" }],
    };
}
```

This will result in an asset `processors/${processor}/${script}-${hash}.js` (e.g. `processors/awesome/awesome-31ce7f.js`) only when the processor is actively enabled by the consumer, i.e. processor runtime scripts are only included in the output when enabled.

This way the runtime will not include unused dead code from unused processors and the scripts does not need to check for presence of the DOM elements added by the processor template (or rather, they can assume they will be present).

Internally processor runtimes are handled in two ways:

* Processors bundled within `@forsakringskassan/docs-generator` will be compiled into the `dist/processors` folder. When enabled scripts will be read from there instead of directly accessing the filename provided by the `src` property.
* Custom processors from the consumer will be assumed to be compiled (or not need compilation) and the `src` property will be used directly as the path to the script.

This way it is easy to add runtime scripts in both cases, just point the `src` property to the file and it will magically do the expected thing.

**EDIT**: a potential downside (or feature when running with HTTP/2 multiplexing) is that this creates multiple assets.