### PR TITLE
refactor: add memoization util

### DIFF
--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -1,0 +1,1 @@
+export { memoize } from "./memoize";

--- a/src/runtime/utils/memoize.spec.ts
+++ b/src/runtime/utils/memoize.spec.ts
@@ -1,0 +1,93 @@
+import { memoize } from "./memoize";
+
+it("should return the result of the callback", () => {
+    expect.assertions(1);
+    const spy = jest.fn(() => 12);
+    const fn = memoize(spy);
+    const result = fn();
+    expect(result).toBe(12);
+});
+
+it("should only evaluate callback once", () => {
+    expect.assertions(2);
+    const spy = jest.fn(() => 42);
+    const fn = memoize(spy);
+    const result1 = fn();
+    const result2 = fn();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result1).toEqual(result2);
+});
+
+it("should be lazy evaluated", () => {
+    expect.assertions(1);
+    const spy = jest.fn(() => 12);
+    memoize(spy);
+    expect(spy).toHaveBeenCalledTimes(0);
+});
+
+it("should handle different arguments", () => {
+    expect.assertions(7);
+    const spy = jest.fn((n: number) => n * 2);
+    const fn = memoize(spy);
+    const result1 = fn(1);
+    const result2 = fn(2);
+    const result3 = fn(1);
+    const result4 = fn(2);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith(1);
+    expect(spy).toHaveBeenCalledWith(2);
+    expect(result1).toBe(2);
+    expect(result2).toBe(4);
+    expect(result3).toEqual(result1);
+    expect(result4).toEqual(result2);
+});
+
+it("should be usable as a decorator", async () => {
+    // expect.assertions(6);
+    const spySync = jest.fn(() => 1);
+    const spyAsync = jest.fn(() => Promise.resolve(2));
+    class MockClass {
+        @memoize
+        public expensiveCallSync(): number {
+            return spySync();
+        }
+
+        @memoize
+        public async expensiveCallAsync(): Promise<number> {
+            return await spyAsync();
+        }
+    }
+    const instance = new MockClass();
+    const result1 = instance.expensiveCallSync();
+    const result2 = instance.expensiveCallSync();
+    const result3 = await instance.expensiveCallAsync();
+    const result4 = await instance.expensiveCallAsync();
+    expect(spySync).toHaveBeenCalledTimes(1);
+    expect(spyAsync).toHaveBeenCalledTimes(1);
+    expect(result1).toBe(1);
+    expect(result3).toBe(2);
+    expect(result1).toEqual(result2);
+    expect(result3).toEqual(result4);
+});
+
+it("should handle async callbacks", async () => {
+    expect.assertions(2);
+    const spy = jest.fn(() => Promise.resolve(12));
+    const fn = memoize(spy);
+    const result1 = await fn();
+    const result2 = await fn();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result1).toEqual(result2);
+});
+
+it("should handle falsy return values", () => {
+    expect.assertions(2 * 4);
+    for (const value of [0, false, null, undefined]) {
+        const spy = jest.fn(() => value);
+        const fn = memoize(spy);
+        const result1 = fn();
+        const result2 = fn();
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result1).toEqual(result2);
+    }
+});

--- a/src/runtime/utils/memoize.ts
+++ b/src/runtime/utils/memoize.ts
@@ -1,0 +1,75 @@
+function cacheKey(...args: unknown[]): string {
+    return JSON.stringify(args);
+}
+
+/**
+ * Creates a new lazy-evaluated and cached function.
+ *
+ * The result of the callback will be cached once evaluated and subsequent calls
+ * will return the cached value. When passing a callback with parameters each
+ * set of arguments are cached individually. The parameters must be serializable
+ * to string.
+ *
+ * @example
+ *
+ * Usage functional style:
+ *
+ * ```ts
+ * function expensiveCalculation() {
+ *     // ...
+ * }
+ *
+ * const fn = memoize(expensiveCalculation);
+ *
+ * // compute the value
+ * const result1 = fn();
+ *
+ * // subsequent calls will be cached
+ * // i.e. result1 === result2
+ * const result2 = fn();
+ * ```
+ *
+ *
+ *
+ * Usage as a decorator:
+ *
+ * ```ts
+ * class AwesomeClass {
+ *     @memoize
+ *     public expensiveCalculation() {
+ *         // ...
+ *     }
+ * }
+ *
+ * // compute the value
+ * const instance = new AwesomeClass();
+ * const result1 = instance.expensiveCalculation();
+ *
+ * // subsequent calls will be cached
+ * // i.e. result1 === result2
+ * const result2 = instance.expensiveCalculation();
+ * ```
+ *
+ * @internal
+ * @param callback - The expensive callback to be memoized.
+ * @returns A wrapped function.
+ */
+export function memoize<TReturn, TArgs extends unknown[]>(
+    callback: (...args: TArgs) => Promise<TReturn>,
+): (...args: TArgs) => Promise<TReturn>;
+export function memoize<TReturn, TArgs extends unknown[]>(
+    callback: (...args: TArgs) => TReturn,
+): (...args: TArgs) => TReturn;
+export function memoize(
+    callback: (...args: unknown[]) => unknown | Promise<unknown>,
+): (...args: unknown[]) => unknown | Promise<unknown> {
+    const cache = new Map<string, unknown | Promise<unknown>>();
+    return (...args: unknown[]) => {
+        const key = cacheKey(args);
+        if (!cache.has(key)) {
+            cache.set(key, callback(...args));
+        }
+        /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- at this point we know the key will exist */
+        return cache.get(key)!;
+    };
+}


### PR DESCRIPTION
Extracted from #48.

Allows for a simple way to cache the result of an expensive or slow computation or network call.

```ts
async function fetchAwesomeResource() {
    const response = await fetch("/awesome/resource");
    return await response.json();
}

const getAwesomeResource = memoize(fetchAwesomeResource);

const resource1 = await getAwesomeResource(); // uncached, calls fetchAwesomeResource()
const resource2 = await getAwesomeResource(); // cached, return cached result from previous call
```

When using parameters each set of parameters is cached individually:

```ts
function computeFibonacci(n) {
    /* ... */
}

const fibonacci = memoize(computeFibonacci);

const first = fibonacci(10); // uncached, calls fibonacci(10)
const second = fibonacci(10); // cached, return cached result from previous call
const third = fibonacci(20); // uncached, calls fibonacci(20)
```

Optionally can be used as a decorator:

```ts
class Awesome {
    @memoize
    public expensiveMethod() {
        /* ... */
    }
}

const fantastic = new Awesome();
fantastic.expensiveMethod(); // automatically wrapped by memoize
```

See ~~PR #48~~ PR #57 for actual usage of this utility.