### PR TITLE
fix: fix broken mermaid diagrams after navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,23 +187,6 @@ MyAwesomeLiveExampleFile.vue
 ```
 ````
 
-#### Diagrams and flowcharts
-
-You can generate diagrams from text by using [Mermaid](https://mermaidjs.github.io/).
-The results are rendered as SVG in the browser.
-
-````md
-```mermaid
-graph TD;
-  A-->B;
-  A-->C;
-  B-->D;
-  C-->D;
-```
-````
-
-You can use the [Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor/) to help write your diagrams.
-
 ### Frontmatter
 
 #### `status`

--- a/docs/markdown/index.md
+++ b/docs/markdown/index.md
@@ -1,4 +1,5 @@
 ---
 title: Markdown
 layout: content-with-menu
+sortorder: 0
 ---

--- a/docs/markdown/mermaid.md
+++ b/docs/markdown/mermaid.md
@@ -1,0 +1,31 @@
+---
+title: Mermaid
+layout: content-with-menu
+---
+
+Diagrams and charts can be created with [Mermaid](https://mermaid.js.org/) in markdown.
+The results are rendered as SVG in the browser.
+
+For instance, a flowchart can be created with:
+
+````md
+```mermaid
+flowchart TD
+  A-->B;
+  A-->C;
+  B-->D;
+  C-->D;
+```
+````
+
+Above will be rendered as:
+
+```mermaid
+flowchart TD
+  A-->B;
+  A-->C;
+  B-->D;
+  C-->D;
+```
+
+You can use the [Mermaid Live Editor](https://mermaid.live/) to help write your diagrams.

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -11,6 +11,7 @@ live-example/index.html
 markdown/code-preview.html
 markdown/custom-containers.html
 markdown/index.html
+markdown/mermaid.html
 navigation/child-page-1.html
 navigation/child-page-2.html
 navigation/child-page-3.html

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -7,6 +7,42 @@ exports[`smoketest 1`] = `
       "children": [
         {
           "external": false,
+          "id": "fs:docs/markdown/index.md",
+          "path": "./markdown/",
+          "sortorder": 0,
+          "title": "Markdown",
+        },
+        {
+          "external": false,
+          "id": "fs:docs/markdown/code-preview.md",
+          "path": "./markdown/code-preview.html",
+          "sortorder": Infinity,
+          "title": "Code preview",
+        },
+        {
+          "external": false,
+          "id": "fs:docs/markdown/custom-containers.md",
+          "path": "./markdown/custom-containers.html",
+          "sortorder": Infinity,
+          "title": "Custom containers",
+        },
+        {
+          "external": false,
+          "id": "fs:docs/markdown/mermaid.md",
+          "path": "./markdown/mermaid.html",
+          "sortorder": Infinity,
+          "title": "Mermaid",
+        },
+      ],
+      "key": "./markdown",
+      "path": "./markdown/",
+      "sortorder": 0,
+      "title": "Markdown",
+    },
+    {
+      "children": [
+        {
+          "external": false,
           "id": "fs:docs/navigation/index.md",
           "path": "./navigation/",
           "sortorder": 1,
@@ -197,35 +233,6 @@ exports[`smoketest 1`] = `
       "path": "",
       "sortorder": Infinity,
       "title": "live-example",
-    },
-    {
-      "children": [
-        {
-          "external": false,
-          "id": "fs:docs/markdown/code-preview.md",
-          "path": "./markdown/code-preview.html",
-          "sortorder": Infinity,
-          "title": "Code preview",
-        },
-        {
-          "external": false,
-          "id": "fs:docs/markdown/custom-containers.md",
-          "path": "./markdown/custom-containers.html",
-          "sortorder": Infinity,
-          "title": "Custom containers",
-        },
-        {
-          "external": false,
-          "id": "fs:docs/markdown/index.md",
-          "path": "./markdown/",
-          "sortorder": Infinity,
-          "title": "Markdown",
-        },
-      ],
-      "key": "./markdown",
-      "path": "./markdown/",
-      "sortorder": Infinity,
-      "title": "Markdown",
     },
   ],
   "key": ".",

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -1,3 +1,4 @@
+import mermaid from "mermaid";
 import { tableOfContents, toggleTableOfContents } from "./table-of-contents";
 
 const parser = new DOMParser();
@@ -163,6 +164,9 @@ function replaceContentOnClick(
             heading.setAttribute("tabindex", "-1");
             heading.focus();
         }
+
+        /* rerender mermaid diagrams */
+        mermaid.contentLoaded();
     });
 }
 

--- a/src/style/_skeleton.scss
+++ b/src/style/_skeleton.scss
@@ -1,0 +1,36 @@
+@keyframes skeleton {
+    from {
+        transform: translateX(-100%);
+    }
+    to {
+        transform: translateX(100%);
+    }
+}
+
+@mixin skeleton-element {
+    border: 1px solid #f4f4f4;
+    border-radius: 4px;
+    background: #ccc;
+    display: inline-block;
+    filter: blur(1px);
+    user-select: none;
+    color: transparent;
+    overflow: hidden;
+    width: 100%;
+    height: 3rem;
+    cursor: wait;
+
+    &::after {
+        content: " ";
+        display: block;
+        inset: 0;
+        position: absolute;
+        transform: translateX(-100%);
+        background: linear-gradient(90deg, transparent, hsla(0deg 0% 100% / 30%), transparent);
+        pointer-events: none;
+
+        @media not (prefers-reduced-motion: reduce) {
+            animation: skeleton 2s infinite;
+        }
+    }
+}

--- a/src/style/core.scss
+++ b/src/style/core.scss
@@ -4,6 +4,7 @@
 @use "navigation";
 @use "outline";
 @use "selectable_version";
+@use "skeleton";
 @use "version_banner";
 
 /* reset broken FKUI reset */
@@ -383,6 +384,10 @@ main #aside dd {
 
 .code-preview code {
     margin: 0;
+}
+
+pre.mermaid:not([data-processed]) {
+    @include skeleton.skeleton-element;
 }
 
 .icon--code {


### PR DESCRIPTION
Extracted from #48.

Fixes mermaid diagrams not being rendered after site navigation.

Additionally adds a skeleton element to prevent the graph source code from being visible while mermaid is loading.

(screen recordings are done with 10mbit network throttling simulate slow network, albeit I would consider that to be pretty good network conditions)

Before:

![mermaid-original](https://github.com/user-attachments/assets/ba912426-bce9-466e-8c0c-b1036c2f3496)

After:

![mermaid-skeleton](https://github.com/user-attachments/assets/a62c4681-53f8-4d81-898a-3315a76551e8)
