### PR TITLE
feat: sass module importer (refs SB-4982)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -1,6 +1,6 @@
-@use "~@forsakringskassan/docs-generator/style/core";
-@use "~@forsakringskassan/docs-generator/style/site";
-@use "~@forsakringskassan/docs-live-example/dist/main";
+@use "@forsakringskassan/docs-generator/style/core";
+@use "@forsakringskassan/docs-generator/style/site";
+@use "@forsakringskassan/docs-live-example/dist/main";
 
 .mermaid p {
     margin-bottom: 0;

--- a/src/sass/compile-sass-string.ts
+++ b/src/sass/compile-sass-string.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { compileStringAsync, NodePackageImporter } from "sass";
-import { tildeImporter } from "./tilde-importer";
+import { moduleImporter } from "./module-importer";
 
 /**
  * @public
@@ -14,7 +14,7 @@ export async function compileSassString(
 ): Promise<void> {
     const result = await compileStringAsync(style, {
         style: "expanded",
-        importers: [new NodePackageImporter(), tildeImporter],
+        importers: [new NodePackageImporter(), moduleImporter],
     });
     await fs.mkdir(path.dirname(dst), { recursive: true });
     await fs.writeFile(dst, result.css, "utf-8");


### PR DESCRIPTION
Resolves both  `~fancyPackage/src/foo.scss` and `fancyPackage/src/foo.css` paths

