### PR TITLE
refactor: internal `hasTemplate`

### DIFF
--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -252,6 +252,8 @@ export interface ProcessorContext {
     getTemplateData<K extends keyof TemplateData>(key: K): TemplateData[K] | undefined;
     // (undocumented)
     getTemplateData(key: string): unknown;
+    // @internal
+    hasTemplate(name: string): boolean;
     // (undocumented)
     log<TArgs extends unknown[]>(...args: TArgs): void;
     // (undocumented)

--- a/src/processor-context.ts
+++ b/src/processor-context.ts
@@ -72,6 +72,13 @@ export interface ProcessorContext {
      */
     getAllTemplateBlocks(): Map<string, Array<TemplateBlockData<unknown>>>;
 
+    /**
+     * Tests if a template with name is present.
+     *
+     * @internal
+     */
+    hasTemplate(name: string): boolean;
+
     setTopNavigation(root: NavigationSection): void;
     setSideNavigation(root: NavigationSection): void;
 

--- a/src/render/nunjucks-processor.ts
+++ b/src/render/nunjucks-processor.ts
@@ -1,7 +1,7 @@
 import cliProgress from "cli-progress";
 import { type Document } from "../document";
 import { type Processor } from "../processor";
-import { render, createTemplateLoader } from "./render";
+import { render } from "./render";
 import { type RenderOptions } from "./render-options";
 
 const progressbar = new cliProgress.SingleBar({
@@ -40,8 +40,6 @@ export function nunjucksProcessor(
             const docs = context.docs.filter((it) => {
                 return it.fileInfo.outputName;
             });
-
-            createTemplateLoader(options.templateFolders);
 
             progressbar.start(docs.length, 0, {
                 filename: docs.length > 0 ? docs[0].fileInfo.fullPath : "",

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -182,8 +182,9 @@ async function compileStandalones(options: {
 /**
  * @internal
  */
-export function createTemplateLoader(folders: string[]): void {
+export function createTemplateLoader(folders: string[]): TemplateLoader {
     loader = new TemplateLoader(folders);
+    return loader;
 }
 
 /**

--- a/src/render/template-loader.ts
+++ b/src/render/template-loader.ts
@@ -41,14 +41,23 @@ export class TemplateLoader implements ILoaderAsync {
         }
     }
 
+    public hasTemplate(name: string): boolean {
+        const { templateCache } = this;
+        const cached = templateCache.get(name);
+        if (cached) {
+            return true;
+        }
+        const filePath = this.findTemplateFile(name);
+        return Boolean(filePath);
+    }
+
     private async resolveTemplate(name: string): Promise<ResolvedTemplate> {
         const { templateCache, folders } = this;
         const cached = templateCache.get(name);
         if (cached) {
             return cached;
         }
-        const searchPaths = folders.map((it) => path.join(it, name));
-        const filePath = searchPaths.find((it) => existsSync(it));
+        const filePath = this.findTemplateFile(name);
         if (!filePath) {
             const searched = folders.map((it) => `  - "${it}"`).join("\n");
             const message = `Failed to resolve template "${name}", searched in:
@@ -62,5 +71,11 @@ Make sure the name is correct and the template file exists in one of the listed 
         const resolved = { content, filePath };
         templateCache.set(name, resolved);
         return resolved;
+    }
+
+    private findTemplateFile(name: string): string | undefined {
+        const { folders } = this;
+        const searchPaths = folders.map((it) => path.join(it, name));
+        return searchPaths.find((it) => existsSync(it));
     }
 }


### PR DESCRIPTION
Denna kan användas för att kolla om en template existerar. I #73 vill jag använda den för att inte bryta bakåtkompatibilitet men kan se fler use cases där man renderar ut innehåll bara om det finns en template (dvs där default är att inget renderas).

Denna är markerad som intern men notera att den också är exponerad i `ProcessorContext` så den kan fortfarande nyttjas även av externa processorer.