### PR TITLE
feat: expose a limited set of esbuild options to js assets

### DIFF
--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -86,7 +86,9 @@ class Generator_2 {
     // (undocumented)
     build(sourceFiles: SourceFiles[]): Promise<string[]>;
     // (undocumented)
-    compileScript(name: string, src: string | URL, options?: Partial<CompileOptions>): void;
+    compileScript(name: string, src: string | URL, options?: Partial<CompileOptions>, buildOptions?: {
+        define?: Record<string, string>;
+    }): void;
     // (undocumented)
     compileStyle(name: string, src: string | URL, options?: Partial<CompileOptions>): void;
     // (undocumented)
@@ -307,6 +309,9 @@ export interface ProcessorOptions {
 
 // @public
 export interface ProcessorRuntime {
+    buildOptions?: {
+        define?: Record<string, string>;
+    };
     name?: string;
     src: string;
 }

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -27,10 +27,11 @@ export async function compileScript(
             platform: "browser",
             external: ["vue", "@fkui/vue"],
             tsconfig: path.join(__dirname, "../tsconfig-examples.json"),
+            ...options,
             define: {
                 "process.env.DOCS_ICON_LIB": JSON.stringify(iconLib),
+                ...options?.define,
             },
-            ...options,
         });
         const content = await fs.readFile(outfile, "utf-8");
         const fingerprint = getFingerprint(content);

--- a/src/assets/js-asset-processor.ts
+++ b/src/assets/js-asset-processor.ts
@@ -1,3 +1,4 @@
+import { type BuildOptions } from "esbuild";
 import { type Processor } from "../processor";
 import { formatSize, serializeAttrs } from "../utils";
 import { type CompileOptions } from "./compile-options";
@@ -10,6 +11,7 @@ export interface JSAsset {
     name: string;
     src: string | URL;
     options: CompileOptions;
+    buildOptions: Pick<BuildOptions, "define">;
 }
 
 function byPriority({ options: a }: JSAsset, { options: b }: JSAsset): number {
@@ -42,6 +44,7 @@ export function jsAssetProcessor(
                     assetFolder,
                     asset.name,
                     asset.src,
+                    asset.buildOptions,
                 );
                 const attrs = serializeAttrs(asset.options.attributes);
                 const inject = { ...info, attrs: Array.from(attrs).join(" ") };

--- a/src/compile-processor-runtime.spec.ts
+++ b/src/compile-processor-runtime.spec.ts
@@ -26,10 +26,15 @@ it("should queue runtime scripts for compilation", () => {
         },
     ]);
     expect(compileScript).toHaveBeenCalledTimes(1);
-    expect(compileScript).toHaveBeenCalledWith("processors/foo/foo", "foo.js", {
-        appendTo: "body",
-        priority: expect.any(Number),
-    });
+    expect(compileScript).toHaveBeenCalledWith(
+        "processors/foo/foo",
+        "foo.js",
+        {
+            appendTo: "body",
+            priority: expect.any(Number),
+        },
+        {},
+    );
 });
 
 it("should handle multiple scripts from same processor", () => {
@@ -45,14 +50,24 @@ it("should handle multiple scripts from same processor", () => {
         },
     ]);
     expect(compileScript).toHaveBeenCalledTimes(2);
-    expect(compileScript).toHaveBeenCalledWith("processors/foo/foo", "foo.js", {
-        appendTo: "body",
-        priority: expect.any(Number),
-    });
-    expect(compileScript).toHaveBeenCalledWith("processors/foo/bar", "bar.js", {
-        appendTo: "body",
-        priority: expect.any(Number),
-    });
+    expect(compileScript).toHaveBeenCalledWith(
+        "processors/foo/foo",
+        "foo.js",
+        {
+            appendTo: "body",
+            priority: expect.any(Number),
+        },
+        {},
+    );
+    expect(compileScript).toHaveBeenCalledWith(
+        "processors/foo/bar",
+        "bar.js",
+        {
+            appendTo: "body",
+            priority: expect.any(Number),
+        },
+        {},
+    );
 });
 
 it("should handle multiple processors with runtime scripts", () => {
@@ -76,14 +91,24 @@ it("should handle multiple processors with runtime scripts", () => {
         },
     ]);
     expect(compileScript).toHaveBeenCalledTimes(2);
-    expect(compileScript).toHaveBeenCalledWith("processors/foo/foo", "foo.js", {
-        appendTo: "body",
-        priority: expect.any(Number),
-    });
-    expect(compileScript).toHaveBeenCalledWith("processors/bar/foo", "foo.js", {
-        appendTo: "body",
-        priority: expect.any(Number),
-    });
+    expect(compileScript).toHaveBeenCalledWith(
+        "processors/foo/foo",
+        "foo.js",
+        {
+            appendTo: "body",
+            priority: expect.any(Number),
+        },
+        {},
+    );
+    expect(compileScript).toHaveBeenCalledWith(
+        "processors/bar/foo",
+        "foo.js",
+        {
+            appendTo: "body",
+            priority: expect.any(Number),
+        },
+        {},
+    );
 });
 
 it("should handle processor without runtime scripts", () => {
@@ -137,8 +162,43 @@ it("should use custom asset name if provided", () => {
         },
     ]);
     expect(compileScript).toHaveBeenCalledTimes(1);
-    expect(compileScript).toHaveBeenCalledWith("processors/foo/bar", "foo.js", {
-        appendTo: "body",
-        priority: expect.any(Number),
-    });
+    expect(compileScript).toHaveBeenCalledWith(
+        "processors/foo/bar",
+        "foo.js",
+        {
+            appendTo: "body",
+            priority: expect.any(Number),
+        },
+        {},
+    );
+});
+
+it("should use custom build options if provided", () => {
+    expect.assertions(2);
+    compileProcessorRuntime(docs, `file://${__filename}`, [
+        {
+            name: "foo",
+            before: "assets",
+            runtime: [
+                { src: "foo.js", buildOptions: { define: { foo: "bar" } } },
+            ],
+            handler() {
+                /* do nothing */
+            },
+        },
+    ]);
+    expect(compileScript).toHaveBeenCalledTimes(1);
+    expect(compileScript).toHaveBeenCalledWith(
+        "processors/foo/foo",
+        "foo.js",
+        {
+            appendTo: "body",
+            priority: expect.any(Number),
+        },
+        {
+            define: {
+                foo: "bar",
+            },
+        },
+    );
 });

--- a/src/compile-processor-runtime.ts
+++ b/src/compile-processor-runtime.ts
@@ -28,10 +28,17 @@ export function compileProcessorRuntime(
             const name = processorRuntimeName(processor, entry);
             const bundled = new URL(`${name}.js`, distDir);
             const scriptPath = existsSync(bundled) ? bundled : entry.src;
-            generator.compileScript(assetName, scriptPath, {
-                appendTo: "body",
-                priority: 50,
-            });
+            generator.compileScript(
+                assetName,
+                scriptPath,
+                {
+                    appendTo: "body",
+                    priority: 50,
+                },
+                {
+                    ...entry.buildOptions,
+                },
+            );
         }
     }
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -286,6 +286,7 @@ export class Generator {
         name: string,
         src: string | URL,
         options?: Partial<CompileOptions>,
+        buildOptions?: { define?: Record<string, string> },
     ): void {
         this.scripts.push({
             name,
@@ -295,6 +296,9 @@ export class Generator {
                 attributes: {},
                 priority: 0,
                 ...options,
+            },
+            buildOptions: {
+                ...buildOptions,
             },
         });
     }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -20,6 +20,11 @@ export interface ProcessorRuntime {
 
     /** Bundle name (in dist/processors) folder (default: derived from processor name) */
     name?: string;
+
+    /** Build options (passed to compileScript) */
+    buildOptions?: {
+        define?: Record<string, string>;
+    };
 }
 
 /**


### PR DESCRIPTION
Detta är lite fränt, nu kan man använda `define: { ... }` från som processor för att kompilera sin runtime asset med config från konsumenten \o/

Konsument:

```ts
awesomeProcessor({
  superDuperOption: "foobar",
}),
```

och i `awesomeProcessor`:

```ts
runtime: [
  {
    src: "src/runtime/awesome.ts",
    buildOptions: {
      define: {
        SUPER_DUPER_OPTION: JSON.stringify(superDuperOption),
      },
  },
]
```

och sist då `runtime/awesome.ts`:

```ts
/* man skulle kunna generera en processor-env.d.ts men någon måtta med augomagin får det väl vara? */
declare const SUPER_DUPER_OPTION: string;

const superDuperOption = SUPER_DUPER_OPTION;
console.log(superDuperOption);
// > foobar
```

Och då är ju frågan alla bör sälla: varför vill man göra det?

Jo, man kan exempelvis exponera ut paketets versionsnummer från konsumenten. Byt mentalt ut `superDuperOption` mot `pkgVersion` som exempel. Compile-time constants.