### PR TITLE
fix: make responsive menu hidden while page is loading

### DIFF
--- a/templates/partials/topnav.html
+++ b/templates/partials/topnav.html
@@ -18,7 +18,7 @@
             </div>
         </li>
         {%- endfor -%}
-        <li class="imenu__list__item imenu__list__item--more">
+        <li class="imenu__list__item imenu__list__item--more" style="visibility: hidden">
             <div class="imenu__list__anchor-container">
                 <button type="button" class="imenu__list__anchor" aria-expanded="false">
                     Mer<span class="imenu__list__anchor-span"></span>
@@ -34,7 +34,10 @@
                     {% set navPath = nav.path | replace("html", "") %}
                     {% set navPath = navPath | replace(".", "") %}
                     {% set activePage = navPath in doc.fileInfo.fullPath %}
-                    <li class="ipopupmenu__list__item {% if activePage %}ipopupmenu__list__item--highlight{% endif %}">
+                    <li
+                        class="ipopupmenu__list__item {% if activePage %}ipopupmenu__list__item--highlight{% endif %}"
+                        style="display: none"
+                    >
                         <a href="{{ nav.path | relative(doc) }}"> {{ nav.title }} </a>
                     </li>
                     {%- endfor -%}


### PR DESCRIPTION
Currently the responsive menu flickers really badly when loading the FKUI documentation

> [!WARNING]
> The starting points of the videos are not 100% the same so don't focus on loading times. Look at the behaviour instead.

This is when running on localhost. Adding a minimal amount of throttling increases the time this is visible significantly. On anything less than 100mbit it is visible for multiple seconds.

**Before:**

![responsive-menu-before](https://github.com/user-attachments/assets/660678cb-fe33-4998-8ed3-13c70f80b913)

**After:**

![responsive-menu-after](https://github.com/user-attachments/assets/69856652-967e-4283-a243-3f2a203a1a68)

---

This mitigates another issue: when navigating the unstyled "more" menu is permanently left in place as the topnav script is not rerun and it does not use the newly loaded elements.