### PR TITLE
feat: support <details> element in markdown content

### DIFF
--- a/docs/markdown/containers/details.md
+++ b/docs/markdown/containers/details.md
@@ -1,0 +1,77 @@
+---
+title: Details
+layout: article
+---
+
+Expandable area using the `<details>` element.
+Implemented as a special variant of {@link messagebox}.
+
+**Input:**
+
+```md
+::: details
+
+Lorem ipsum dolor sit amet.
+
+-   Foo
+-   Bar
+-   Baz
+
+:::
+```
+
+**Output:**
+
+::: details
+
+Lorem ipsum dolor sit amet.
+
+-   Foo
+-   Bar
+-   Baz
+
+:::
+
+Title can optionally be specified:
+
+**Input:**
+
+```md
+::: details Click me!
+
+Lorem **ipsum** dolor sit amet.
+
+-   foo
+-   bar
+-   baz
+
+:::
+```
+
+**Output:**
+
+::: details Click me!
+
+Lorem **ipsum** dolor sit amet.
+
+-   foo
+-   bar
+-   baz
+
+:::
+
+## Localization
+
+Uses the same `messagebox.title` property as messageboxes with `details` as key.
+
+```ts
+const docs = new Generator({
+    markdown: {
+        messagebox: {
+            title: {
+                details: "Läs mer",
+            },
+        },
+    },
+});
+```

--- a/docs/markdown/containers/messagebox.md
+++ b/docs/markdown/containers/messagebox.md
@@ -1,6 +1,6 @@
 ---
 title: Messagebox
-layout: pattern
+layout: article
 ---
 
 Messageboxes can be added with:

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -15,6 +15,7 @@ live-example/index.html
 markdown/code-preview/fullscreen.html
 markdown/code-preview/index.html
 markdown/containers/alt-text.html
+markdown/containers/details.html
 markdown/containers/messagebox.html
 markdown/definition-lists.html
 markdown/index.html

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -45,6 +45,13 @@ exports[`smoketest 1`] = `
             },
             {
               "external": false,
+              "id": "fs:docs/markdown/containers/details.md",
+              "path": "./markdown/containers/details.html",
+              "sortorder": Infinity,
+              "title": "Details",
+            },
+            {
+              "external": false,
               "id": "fs:docs/markdown/containers/messagebox.md",
               "path": "./markdown/containers/messagebox.html",
               "sortorder": Infinity,

--- a/src/render/markdown/container-renderer.ts
+++ b/src/render/markdown/container-renderer.ts
@@ -7,6 +7,7 @@ import {
     type ContainerContext,
     altContainer,
     apiContainer,
+    detailsContainer,
     messageboxContainer,
 } from "./container";
 
@@ -158,6 +159,7 @@ export function containerRenderer(
         md.use(containerParser, {
             alt: altContainer(context),
             api: apiContainer(context),
+            details: detailsContainer(context, options.messagebox),
             messagebox: messageboxContainer(context, options.messagebox),
 
             /* aliases for messagebox containers */

--- a/src/render/markdown/container/details-container.spec.ts
+++ b/src/render/markdown/container/details-container.spec.ts
@@ -1,0 +1,120 @@
+import dedent from "dedent";
+import markdownIt from "markdown-it";
+import { type FileInfo } from "../../../document";
+import { containerParser } from "../container-renderer";
+import { type ContainerContext } from "./container-context";
+import { detailsContainer } from "./details-container";
+
+expect.addSnapshotSerializer({
+    test() {
+        return true;
+    },
+    serialize(value: string) {
+        return dedent(value)
+            .split(/\n/g)
+            .map((it) => it.trimEnd())
+            .filter((it) => it.length > 0)
+            .join("\n");
+    },
+});
+
+const md = markdownIt();
+const context: ContainerContext = {
+    md,
+    env: {
+        fileInfo: {} as FileInfo,
+        ids: new Set(),
+    },
+    docs: [],
+    included: new Set(),
+    handleSoftError(err) {
+        throw err;
+    },
+};
+
+md.use(containerParser, {
+    details: detailsContainer(context, { title: {} }),
+});
+
+it("should render details", () => {
+    expect.assertions(1);
+    const source = dedent`
+        ::: details
+        foo
+        :::
+    `;
+    const result = md.render(source);
+    expect(result).toMatchInlineSnapshot(`
+        <details class="docs-messagebox docs-messagebox--details">
+            <summary class="docs-messagebox__title">
+                Details
+            </summary>
+            <p>foo</p>
+        </details>
+    `);
+});
+
+it("should render custom heading", () => {
+    expect.assertions(1);
+    const source = dedent`
+        ::: details Lorem ipsum
+        dolor sit amet
+        :::
+    `;
+    const result = md.render(source);
+    expect(result).toMatchInlineSnapshot(`
+        <details class="docs-messagebox docs-messagebox--details">
+            <summary class="docs-messagebox__title">
+                Lorem ipsum
+            </summary>
+            <p>dolor sit amet</p>
+        </details>
+    `);
+});
+
+it("should render nested markdown", () => {
+    expect.assertions(1);
+    const source = dedent`
+        ::: details foo \`bar\` baz
+
+        * foo **bar** baz
+
+        :::
+    `;
+    const result = md.render(source);
+    expect(result).toMatchInlineSnapshot(`
+        <details class="docs-messagebox docs-messagebox--details">
+            <summary class="docs-messagebox__title">
+                foo <code>bar</code> baz
+            </summary>
+            <ul>
+        <li>foo <strong>bar</strong> baz</li>
+        </ul>
+        </details>
+    `);
+});
+
+it("should use localized title", () => {
+    expect.assertions(1);
+    const md = markdownIt();
+    md.use(containerParser, {
+        details: detailsContainer(context, {
+            title: { details: "Localized title" },
+        }),
+    });
+    /* tip is configured with a localized title */
+    const source = dedent`
+        ::: details
+        foo
+        :::
+    `;
+    const result = md.render(source);
+    expect(result).toMatchInlineSnapshot(`
+        <details class="docs-messagebox docs-messagebox--details">
+            <summary class="docs-messagebox__title">
+                Localized title
+            </summary>
+            <p>foo</p>
+        </details>
+    `);
+});

--- a/src/render/markdown/container/details-container.ts
+++ b/src/render/markdown/container/details-container.ts
@@ -1,0 +1,38 @@
+import { type ContainerCallback } from "./container-callback";
+import { type ContainerContext } from "./container-context";
+
+/**
+ * Create a container renderer "details" to render details (special variant of
+ * messagebox).
+ *
+ * @internal
+ */
+export function detailsContainer(
+    context: ContainerContext,
+    options: { title: Record<string, string | undefined> },
+): ContainerCallback {
+    const { md, env } = context;
+
+    function parseInfo(info: string | undefined): string {
+        const customTitle = info ? info.split(" ") : [];
+        if (customTitle.length > 0) {
+            return customTitle.join(" ");
+        } else {
+            return options.title["details"] || "Details";
+        }
+    }
+
+    return (tokens, index) => {
+        const token = tokens[index];
+        const title = parseInfo(token.info);
+        const text = token.content.trim();
+        return /* HTML */ `
+            <details class="docs-messagebox docs-messagebox--details">
+                <summary class="docs-messagebox__title">
+                    ${md.renderInline(title, env)}
+                </summary>
+                ${md.render(text, env)}
+            </details>
+        `;
+    };
+}

--- a/src/render/markdown/container/index.ts
+++ b/src/render/markdown/container/index.ts
@@ -2,4 +2,5 @@ export { altContainer } from "./alt-container";
 export { apiContainer } from "./api-container";
 export { type ContainerCallback } from "./container-callback";
 export { type ContainerContext } from "./container-context";
+export { detailsContainer } from "./details-container";
 export { messageboxContainer } from "./messagebox-container";

--- a/src/render/markdown/container/messagebox-container.spec.ts
+++ b/src/render/markdown/container/messagebox-container.spec.ts
@@ -131,6 +131,26 @@ it("should render custom variant", () => {
     `);
 });
 
+it("should render nested markdown", () => {
+    expect.assertions(1);
+    const source = dedent`
+        ::: info foo \`bar\` baz
+
+        * foo **bar** baz
+
+        :::
+    `;
+    const result = md.render(source);
+    expect(result).toMatchInlineSnapshot(`
+        <div class="docs-messagebox docs-messagebox--info">
+            <p class="docs-messagebox__title">foo <code>bar</code> baz</p>
+            <ul>
+        <li>foo <strong>bar</strong> baz</li>
+        </ul>
+        </div>
+    `);
+});
+
 it("should handle missing leading space", () => {
     expect.assertions(1);
     const source = dedent`

--- a/src/render/markdown/container/messagebox-container.ts
+++ b/src/render/markdown/container/messagebox-container.ts
@@ -1,7 +1,7 @@
 import { type ContainerCallback } from "./container-callback";
 import { type ContainerContext } from "./container-context";
 
-const defaultTitle: Record<string, string> = {
+const defaultTitle: Record<string, string | undefined> = {
     info: "INFO",
     warning: "WARNING",
     danger: "DANGER",
@@ -15,7 +15,7 @@ const defaultTitle: Record<string, string> = {
  */
 export function messageboxContainer(
     context: ContainerContext,
-    options: { title: Record<string, string> },
+    options: { title: Record<string, string | undefined> },
     alias?: string,
 ): ContainerCallback {
     const { md, env } = context;
@@ -53,11 +53,15 @@ export function messageboxContainer(
         const token = tokens[index];
         const { variant, title } = parseInfo(token.info);
         const text = token.content.trim();
-        const content = md.render(text, env);
         return /* HTML */ `
             <div class="docs-messagebox docs-messagebox--${variant}">
-                ${title ? `<p class="docs-messagebox__title">${title}</p>` : ""}
-                ${content}
+                ${title
+                    ? `<p class="docs-messagebox__title">${md.renderInline(
+                          title,
+                          env,
+                      )}</p>`
+                    : ""}
+                ${md.render(text, env)}
             </div>
         `;
     };

--- a/src/style/_messagebox.scss
+++ b/src/style/_messagebox.scss
@@ -12,6 +12,22 @@
         font-weight: bold;
     }
 
+    &--details {
+        border-color: var(--docs-messagebox-details-border);
+        background: var(--docs-messagebox-details-background);
+
+        summary {
+            cursor: pointer;
+            margin: -1.5rem;
+            padding: 1.5rem;
+        }
+
+        &[open] summary {
+            margin-bottom: 0;
+            padding-bottom: 0.75rem;
+        }
+    }
+
     &--info {
         border-color: var(--docs-messagebox-info-border);
         background: var(--docs-messagebox-info-background);

--- a/src/style/css-variables.mjs
+++ b/src/style/css-variables.mjs
@@ -108,6 +108,16 @@ export default {
     messagebox: {
         description: "Style related to markdown messageboxes.",
         variables: {
+            "details-border": {
+                description: "Border color for details variant",
+                type: "color",
+                value: "#bbbbbd",
+            },
+            "details-background": {
+                description: "Background color for details variant",
+                type: "color",
+                value: "#f4f4f4",
+            },
             "info-border": {
                 description: "Border color for info variant",
                 type: "color",


### PR DESCRIPTION
Stöd för expanderbara ytor med `<details>` elementet. Själva `<details>` och `<summary>` (titel) är ostylat men la på en grå bakgrund och border tills vidare. @krehnst återkommer med skiss för hur det bör se ut senare.

**Kollapsad:**

![image](https://github.com/user-attachments/assets/e89a1694-99b1-4d1a-9adb-3224ed8a58b6)

**Expanderad:**

![image](https://github.com/user-attachments/assets/a1ccd9ae-44df-4a82-a5ee-4e4722d0c791)
