### PR TITLE
fix: fix `cannot read property of null` when clicking on topnav

### DIFF
--- a/src/runtime/topnav.ts
+++ b/src/runtime/topnav.ts
@@ -74,15 +74,6 @@ function closePopoverOnEsc(event: KeyboardEvent, refs: Refs): void {
     }
 }
 
-function onClickItem(event: Event): void {
-    const clickable = (event.target as HTMLElement).querySelector<HTMLElement>(
-        "a, button",
-    );
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- accept runtime error
-    clickable!.click();
-}
-
 function onClickPopover(event: Event): void {
     event.stopPropagation();
 }
@@ -143,11 +134,6 @@ function setup(): Refs | undefined {
     const refs = getElementsRefs();
     if (!refs) {
         return;
-    }
-
-    for (const pair of refs.itemPairs) {
-        pair.menu.addEventListener("click", onClickItem);
-        pair.popover.addEventListener("click", onClickItem);
     }
 
     refs.moreItem.addEventListener("click", (e) => togglePopover(e, refs));


### PR DESCRIPTION
Click handlern kastar alltid en exception. Är inte riktigt säker på vad avsikten med funktionen är men jag får alltid in `<a>`  taggen som `event.target` så behöver inte leta upp den.

@dvitamin Missar jag något här?

![image](https://github.com/user-attachments/assets/45d1957f-8ecc-4394-979b-bde131d061bb)
