### PR TITLE
fix: fix performance regression when using sourceUrlProcessor

### DIFF
--- a/docs/processors/source-url.md
+++ b/docs/processors/source-url.md
@@ -37,6 +37,13 @@ The `sourceUrlProcessor` takes a configuration object:
 
 Enables/disables the processor.
 
+### `sourceFiles`
+
+-   Type: `string[]`
+-   Default: `[**/*]`
+
+List of patterns to match source files.
+
 ### `urlFormat`
 
 -   Type: `string`

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -371,6 +371,7 @@ export function sourceUrlProcessor(options: SourceUrlProcessorOptions): Processo
 // @public
 export interface SourceUrlProcessorOptions extends ProcessorOptions {
     readonly componentFileExtension?: string;
+    readonly sourceFiles?: string[];
     // (undocumented)
     readonly urlFormat: string;
 }

--- a/generate-docs.mjs
+++ b/generate-docs.mjs
@@ -42,6 +42,7 @@ const docs = new Generator({
                 : undefined,
         }),
         sourceUrlProcessor(pkg, {
+            sourceFiles: ["docs/**"],
             urlFormat: "{{ repository }}/tree/main/{{ path }}",
             componentFileExtension: "baz",
         }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "jest-environment-jsdom": "29.7.0",
         "lint-staged": "15.2.10",
         "memfs": "4.12.0",
+        "minimatch": "10.0.1",
         "npm-pkg-lint": "3.9.0",
         "npm-run-all2": "6.2.3",
         "rollup": "4.24.0",
@@ -5069,6 +5070,22 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
@@ -10880,21 +10897,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob/node_modules/path-scurry": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
@@ -11329,6 +11331,23 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/html-validate/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/http-errors": {
@@ -15835,16 +15854,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -16052,6 +16070,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm-run-all2/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "jest-environment-jsdom": "29.7.0",
     "lint-staged": "15.2.10",
     "memfs": "4.12.0",
+    "minimatch": "10.0.1",
     "npm-pkg-lint": "3.9.0",
     "npm-run-all2": "6.2.3",
     "rollup": "4.24.0",

--- a/src/examples/get-example-import.ts
+++ b/src/examples/get-example-import.ts
@@ -5,6 +5,7 @@ import { normalizePath } from "../utils";
  * Search filename in directories (deep).
  *
  * @internal
+ * @deprecated use `fileMatcher()` instead, this function is insanely slow
  */
 export function getExampleImport(
     searchDirs: string[],

--- a/src/processors/source-url-processor.ts
+++ b/src/processors/source-url-processor.ts
@@ -1,8 +1,12 @@
 import { ProcessorOptions, type Processor } from "../processor";
 import { Component } from "../document";
-import { getExampleImport } from "../examples";
 import { type PackageJson } from "../package-json";
-import { getRepositoryUrl, gitCommitHash, interpolate } from "../utils";
+import {
+    getRepositoryUrl,
+    gitCommitHash,
+    interpolate,
+    fileMatcher,
+} from "../utils";
 
 /**
  * Options for {@link sourceUrlProcessor#}.
@@ -50,6 +54,7 @@ export function sourceUrlProcessor(
     } = options;
 
     const repository = getRepositoryUrl(pkg) ?? "";
+    const matcher = fileMatcher(["**/*"]);
 
     return {
         after: "generate-docs",
@@ -67,7 +72,7 @@ export function sourceUrlProcessor(
             ): string | undefined {
                 const { source, name } = component;
                 const filename = source ?? `${name}.${componentFileExtension}`;
-                const path = getExampleImport(["./"], filename);
+                const path = matcher(filename, "when generating source url");
                 return interpolate(urlFormat, {
                     path,
                     hash,

--- a/src/processors/source-url-processor.ts
+++ b/src/processors/source-url-processor.ts
@@ -14,7 +14,11 @@ import {
  * @public
  */
 export interface SourceUrlProcessorOptions extends ProcessorOptions {
+    /** List of glob patterns matching source files */
+    readonly sourceFiles?: string[];
+
     readonly urlFormat: string;
+
     /** File extension used for finding component by name */
     readonly componentFileExtension?: string;
 }
@@ -49,12 +53,13 @@ export function sourceUrlProcessor(
     const options = args.length === 2 ? args[1] : args[0];
     const {
         enabled = true,
+        sourceFiles = ["**/*"],
         urlFormat,
         componentFileExtension = "vue",
     } = options;
 
     const repository = getRepositoryUrl(pkg) ?? "";
-    const matcher = fileMatcher(["**/*"]);
+    const matcher = fileMatcher(sourceFiles);
 
     return {
         after: "generate-docs",

--- a/src/utils/file-matcher.ts
+++ b/src/utils/file-matcher.ts
@@ -1,0 +1,36 @@
+import { globSync } from "glob";
+import { minimatch } from "minimatch";
+import { memoize } from "./memoize";
+
+/**
+ * Create a matcher which returns the full path given a filename, partial path
+ * to a filename or minimatch pattern.
+ *
+ * Throws an error if zero or more than one paths match.
+ *
+ * @internal
+ * @param patterns - Minimatch patterns to match all possible files.
+ */
+export function fileMatcher(
+    patterns: string[],
+): (filename: string, context?: string) => string {
+    const fileList = globSync(patterns, {
+        posix: true,
+        ignore: "**/node_modules/**",
+    });
+
+    return memoize((filename: string, context?: string) => {
+        const matches = minimatch.match(fileList, `**/${filename}`);
+        if (matches.length === 0) {
+            const additionalInfo = context ? ` (${context})` : "";
+            const message = `No files matched pattern "${filename}"${additionalInfo}`;
+            throw new Error(message);
+        } else if (matches.length > 1) {
+            const additionalInfo = context ? ` (${context})` : "";
+            const message = `Multiple files matched pattern "${filename}"${additionalInfo}. Searched in [${patterns.join(", ")}]`;
+            throw new Error(message);
+        } else {
+            return matches[0];
+        }
+    });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { createMockDocument } from "./create-mock-document";
+export { fileMatcher } from "./file-matcher";
 export { findDocument } from "./find-document";
 export { formatSize } from "./format-size";
 export { generateId } from "./generate-id";


### PR DESCRIPTION
Från ~6 sekunder per fil till några hundra millisekunder.

Flera saker som spelar in här. Tidigare så matchades komponentens namn mot `**/${name}.${ext}` för varje förekomst i varje fil. Det inkluderar hela `node_modules`.

Nu så cachas det i flera nivåer:

* Vid uppstart läses listan över filer in från disk. Det besparar oss från att läsa ut lista över filer från filsystemet för varje url som ska genereras. Listan har hårdkodat i sig att exkludera `node_modules`.
* Vid själva matchningen så cachas resultatet igen per filnamn, så om samma filnamn efterfrågas två gånger så blir resultatet cachat.
* Och relaterat är att det nu finns en parameter `sourceFiles` där man kan peka ut mer specifikt vilka filer det rör sig om. Vi behöver exempelvis inte ha med `coverage` rapporten i kandidater att matcha filnamnet.

`getExampleImports` borde vi inte använda längre men den nyttjas fortfarande av markdown renderingen. Jag skriver upp det mentalt att fixa senare. Vi kan nog spara in ganska mycket tid där också men den letar iaf inte i ´**/*` så inte lika allvarligt och kräver lite mer refaktorisering för att kunna byta.