### PR TITLE
feat: bundle highlight styling (refs SB-4982)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -57,6 +57,7 @@ async function buildStyle(entrypoints) {
         console.log("Building", src, "->", dst);
         const result = await sass.compileAsync(src, {
             style: "expanded",
+            loadPaths: ["./node_modules"],
             importers: [sassCSSVariableImporter],
         });
         await fs.mkdir(path.dirname(dst), { recursive: true });

--- a/src/style/core.scss
+++ b/src/style/core.scss
@@ -8,6 +8,7 @@
 @use "skeleton";
 @use "tags";
 @use "version_banner";
+@use "highlight.js/styles/default";
 
 /* reset broken FKUI reset */
 dialog {


### PR DESCRIPTION
Konsumenter utav docs-generator skall inte behöva dra in nödvändig styling för hilight-js, de skall inte bry sig om att det nyttjas öht. :-)

Denna raden går därmed att ta bort:
* https://github.com/Forsakringskassan/designsystem/blob/main/docs/src/docs-theme.scss#L8