### PR TITLE
test: use different jest configuration for runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,25 @@
       "!**/index.[jt]s",
       "!**/__fixtures__/**"
     ],
-    "preset": "@forsakringskassan/jest-config"
+    "preset": "@forsakringskassan/jest-config",
+    "projects": [
+      {
+        "displayName": "node",
+        "preset": "@forsakringskassan/jest-config",
+        "testPathIgnorePatterns": [
+          "/node_modules/",
+          "<rootDir>/src/runtime"
+        ]
+      },
+      {
+        "displayName": "browser",
+        "preset": "@forsakringskassan/jest-config",
+        "testMatch": [
+          "<rootDir>/src/runtime/**/*.spec.[jt]s"
+        ],
+        "testEnvironment": "jest-environment-jsdom"
+      }
+    ]
   },
   "dependencies": {
     "@leeoniya/ufuzzy": "1.0.14",
@@ -171,11 +189,6 @@
       "optional": true
     }
   },
-  "overrides": {
-    "nunjucks": {
-      "chokidar": "$chokidar"
-    }
-  },
   "engines": {
     "node": ">= 20.5"
   },
@@ -184,5 +197,10 @@
     "nunjucks",
     "piscina",
     "vue-docgen-api"
-  ]
+  ],
+  "overrides": {
+    "nunjucks": {
+      "chokidar": "$chokidar"
+    }
+  }
 }

--- a/src/runtime/code-preview.spec.ts
+++ b/src/runtime/code-preview.spec.ts
@@ -1,5 +1,3 @@
-/** @jest-environment jsdom */
-
 import { toggleMarkup } from "./code-preview";
 
 jest.useFakeTimers();


### PR DESCRIPTION
Resolves build issue from #73.

The `src/runtime` folder now gets a different config with JSDOM environment.

![image](https://github.com/user-attachments/assets/232132b5-66fd-485a-82f5-776e86f518b1)
