### PR TITLE
docs: add hidden smoketest for table

### DIFF
--- a/docs/navigation/index.md
+++ b/docs/navigation/index.md
@@ -53,6 +53,8 @@ This page will be rendered but will not be visible in the menu.
 It can be linked to by other means.
 ```
 
+If a section (`index.md`) is hidden it will still generate a navigation tree but will not be rendered in the menu.
+
 ## Expandable groups
 
 Each folder with new files will be a expandable group.

--- a/docs/smoketest/index.md
+++ b/docs/smoketest/index.md
@@ -1,0 +1,7 @@
+---
+title: Smoketest
+visible: false
+layout: article
+---
+
+Test pages for various components.

--- a/docs/smoketest/table.md
+++ b/docs/smoketest/table.md
@@ -1,0 +1,67 @@
+---
+title: "Smoketest: tables"
+short-title: Tables
+layout: article
+---
+
+## Narrow table
+
+Narrow on all screen sizes.
+
+| A   | B   | C   |
+| --- | --- | --- |
+| a   | b   | c   |
+| d   | e   | f   |
+| g   | h   | i   |
+
+## Wide table
+
+Wide on most screen sizes.
+
+| A                          | B                          | C                          |
+| -------------------------- | -------------------------- | -------------------------- |
+| Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet |
+| Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet |
+| Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet |
+
+## Ultra wide table
+
+Wide on all screen sizes.
+
+| A                                                        | B                                                        | C                                                        |
+| -------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. |
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. |
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. |
+
+## In details
+
+::: details Narrow
+
+| A   | B   | C   |
+| --- | --- | --- |
+| a   | b   | c   |
+| d   | e   | f   |
+| g   | h   | i   |
+
+:::
+
+::: details Wide
+
+| A                          | B                          | C                          |
+| -------------------------- | -------------------------- | -------------------------- |
+| Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet |
+| Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet |
+| Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet | Lorem ipsum dolor sit amet |
+
+:::
+
+::: details Ultra wide
+
+| A                                                        | B                                                        | C                                                        |
+| -------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. |
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. |
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. | Lorem ipsum dolor sit amet, consectetur adipiscing elit. |
+
+:::

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -40,5 +40,7 @@ processors/source-url.html
 processors/topnav.html
 processors/version.html
 search-data-[hash].json
+smoketest/index.html
+smoketest/table.html
 theme/index.html
 ```

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -206,6 +206,8 @@ export interface NavigationSection {
     readonly sortorder: number;
     // (undocumented)
     readonly title: string;
+    // (undocumented)
+    readonly visible: boolean;
 }
 
 // @public (undocumented)
@@ -406,7 +408,11 @@ export interface TopnavEntry {
     // (undocumented)
     path: string;
     // (undocumented)
+    sortorder?: number;
+    // (undocumented)
     title: string;
+    // (undocumented)
+    visible?: boolean;
 }
 
 // @public

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -183,6 +183,7 @@ function createContext(
         path: "",
         sortorder: Infinity,
         children: [],
+        visible: true,
     };
     let sidenav: NavigationSection = {
         key: ".",
@@ -190,6 +191,7 @@ function createContext(
         path: "",
         sortorder: Infinity,
         children: [],
+        visible: true,
     };
     const templateData: Record<string, unknown> = {};
     return {

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -324,6 +324,22 @@ exports[`smoketest 1`] = `
       "title": "live-example",
       "visible": true,
     },
+    {
+      "children": [
+        {
+          "external": false,
+          "id": "fs:docs/smoketest/table.md",
+          "path": "./smoketest/table.html",
+          "sortorder": Infinity,
+          "title": "Tables",
+        },
+      ],
+      "key": "./smoketest",
+      "path": "",
+      "sortorder": Infinity,
+      "title": "Smoketest",
+      "visible": false,
+    },
   ],
   "key": ".",
   "path": "",

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -33,6 +33,7 @@ exports[`smoketest 1`] = `
           "path": "./markdown/code-preview/",
           "sortorder": Infinity,
           "title": "Code preview",
+          "visible": true,
         },
         {
           "children": [
@@ -62,6 +63,7 @@ exports[`smoketest 1`] = `
           "path": "",
           "sortorder": Infinity,
           "title": "containers",
+          "visible": true,
         },
         {
           "external": false,
@@ -82,6 +84,7 @@ exports[`smoketest 1`] = `
       "path": "./markdown/",
       "sortorder": 0,
       "title": "Markdown",
+      "visible": true,
     },
     {
       "children": [
@@ -118,6 +121,7 @@ exports[`smoketest 1`] = `
       "path": "./layout/",
       "sortorder": 1,
       "title": "Layout",
+      "visible": true,
     },
     {
       "children": [
@@ -177,6 +181,7 @@ exports[`smoketest 1`] = `
           "path": "",
           "sortorder": Infinity,
           "title": "group",
+          "visible": true,
         },
         {
           "children": [
@@ -213,12 +218,14 @@ exports[`smoketest 1`] = `
           "path": "",
           "sortorder": Infinity,
           "title": "sorted-group",
+          "visible": true,
         },
       ],
       "key": "./navigation",
       "path": "./navigation/",
       "sortorder": 1,
       "title": "Navigation",
+      "visible": true,
     },
     {
       "children": [
@@ -283,6 +290,7 @@ exports[`smoketest 1`] = `
       "path": "./processors/",
       "sortorder": 1,
       "title": "Processors",
+      "visible": true,
     },
     {
       "children": [
@@ -298,6 +306,7 @@ exports[`smoketest 1`] = `
       "path": "./theme/",
       "sortorder": 1,
       "title": "Theme",
+      "visible": true,
     },
     {
       "children": [
@@ -313,11 +322,13 @@ exports[`smoketest 1`] = `
       "path": "",
       "sortorder": Infinity,
       "title": "live-example",
+      "visible": true,
     },
   ],
   "key": ".",
   "path": "",
   "sortorder": Infinity,
   "title": "Todo",
+  "visible": true,
 }
 `;

--- a/src/navigation/generate-navtree.spec.ts
+++ b/src/navigation/generate-navtree.spec.ts
@@ -43,6 +43,7 @@ it("should create root node", () => {
         title: "",
         path: "",
         sortorder: Infinity,
+        visible: true,
         children: [],
     });
 });
@@ -54,6 +55,7 @@ it("should merge root index.md to root node", () => {
         title: "Frontpage",
         path: "",
         sortorder: Infinity,
+        visible: true,
         children: [],
     });
 });
@@ -96,6 +98,40 @@ it("should ignore documents with visible false", () => {
         path: "",
         sortorder: Infinity,
         children: [],
+        visible: true,
+    });
+});
+
+it("should not ignore sections with visible false", () => {
+    const nav = generateNavtree([
+        createDocument("index.md", "Frontpage"),
+        createDocument("foo/index.md", "Foo", { visible: false }),
+        createDocument("foo/bar.md", "Bar"),
+    ]);
+    expect(nav).toEqual({
+        key: ".",
+        title: "Frontpage",
+        path: "",
+        sortorder: Infinity,
+        visible: true,
+        children: [
+            {
+                key: "./foo",
+                title: "Foo",
+                path: "",
+                sortorder: Infinity,
+                visible: false,
+                children: [
+                    {
+                        id: "mock:foo/bar.md",
+                        title: "Bar",
+                        path: "./foo/bar.html",
+                        sortorder: Infinity,
+                        external: false,
+                    },
+                ],
+            },
+        ],
     });
 });
 
@@ -113,12 +149,14 @@ it("should create children for each folder", () => {
         title: "Frontpage",
         path: "",
         sortorder: Infinity,
+        visible: true,
         children: [
             {
                 key: "./usage",
                 title: "Usage guide",
                 path: "./usage/",
                 sortorder: Infinity,
+                visible: true,
                 children: [
                     {
                         id: "mock:usage/index.md",
@@ -141,6 +179,7 @@ it("should create children for each folder", () => {
                 title: "Components",
                 path: "./components/",
                 sortorder: 10,
+                visible: true,
                 children: [
                     {
                         id: "mock:components/index.md",
@@ -171,12 +210,14 @@ it("should create children for each folder (inverse order)", () => {
         title: "Frontpage",
         path: "",
         sortorder: 10,
+        visible: true,
         children: [
             {
                 key: "./components",
                 title: "Components",
                 path: "./components/",
                 sortorder: Infinity,
+                visible: true,
                 children: [
                     {
                         id: "mock:components/index.md",
@@ -192,6 +233,7 @@ it("should create children for each folder (inverse order)", () => {
                 title: "Usage guide",
                 path: "./usage/",
                 sortorder: 20,
+                visible: true,
                 children: [
                     {
                         id: "mock:usage/index.md",
@@ -231,12 +273,14 @@ it("should create children for subpages", () => {
         title: "Frontpage",
         path: "",
         sortorder: Infinity,
+        visible: true,
         children: [
             {
                 key: "./a",
                 title: "A",
                 path: "./a/",
                 sortorder: Infinity,
+                visible: true,
                 children: [
                     {
                         id: "mock:a/index.md",
@@ -266,6 +310,7 @@ it("should create children for subpages", () => {
                 title: "B",
                 path: "./b/",
                 sortorder: Infinity,
+                visible: true,
                 children: [
                     {
                         id: "mock:b/index.md",
@@ -293,6 +338,7 @@ it("should create children for subpages", () => {
                         title: "B > C",
                         path: "./b/c/",
                         sortorder: Infinity,
+                        visible: true,
                         children: [
                             {
                                 id: "mock:b/c/index.md",
@@ -336,12 +382,14 @@ it("should read title and sortorder from hidden index.md", () => {
         title: ".",
         path: "",
         sortorder: Infinity,
+        visible: true,
         children: [
             {
                 key: "./usage",
                 title: "Usage guide",
                 path: "",
                 sortorder: 10,
+                visible: false,
                 children: [
                     {
                         id: "mock:usage/foo.md",

--- a/src/navigation/generate-navtree.ts
+++ b/src/navigation/generate-navtree.ts
@@ -23,6 +23,7 @@ export interface NavigationSection {
     readonly path: string;
     readonly sortorder: number;
     readonly children: NavigationNode[];
+    readonly visible: boolean;
 }
 
 /**
@@ -64,18 +65,21 @@ export function generateNavtree(docs: Document[]): NavigationSection {
         key: string,
         title: string,
         sortorder: number,
+        { visible }: { visible?: boolean } = {},
     ): void {
         const existing = section[key];
         if (existing) {
             existing.title = title;
             existing.sortorder = sortorder;
+            existing.visible = visible ?? true;
         } else {
-            const node: NavigationSection = {
+            const node: MutableNavigationSection = {
                 key,
                 title,
                 path: "",
                 sortorder,
                 children: [],
+                visible: visible ?? true,
             };
             section[key] = node;
             if (key !== ".") {
@@ -101,6 +105,7 @@ export function generateNavtree(docs: Document[]): NavigationSection {
             path: "",
             sortorder: Infinity,
             children: [],
+            visible: true,
         };
         section[parentKey] = parent;
         let anchestor = parentKey;
@@ -111,12 +116,13 @@ export function generateNavtree(docs: Document[]): NavigationSection {
                 section[anchestor].children.push(current);
                 break;
             }
-            const node: NavigationSection = {
+            const node: MutableNavigationSection = {
                 key: anchestor,
                 title: "",
                 path: "",
                 sortorder: Infinity,
                 children: [current],
+                visible: true,
             };
             section[anchestor] = node;
             current = node;
@@ -158,7 +164,7 @@ export function generateNavtree(docs: Document[]): NavigationSection {
         /* ignore documents with are marked as not navigatable */
         if (!doc.visible) {
             if (isSection) {
-                createSection(name, title, sortorder);
+                createSection(name, title, sortorder, { visible: false });
             }
             continue;
         }
@@ -186,13 +192,15 @@ export function generateNavtree(docs: Document[]): NavigationSection {
                 existing.path = leafNode.path;
                 existing.sortorder = sortorder;
                 existing.children.unshift(leafNode);
+                existing.visible = true;
             } else {
-                const sectionNode: NavigationSection = {
+                const sectionNode: MutableNavigationSection = {
                     key: name,
                     title,
                     path: leafNode.path,
                     sortorder,
                     children: [leafNode],
+                    visible: true,
                 };
                 section[name] = sectionNode;
                 parent.children.push(sectionNode);
@@ -219,6 +227,7 @@ export function generateNavtree(docs: Document[]): NavigationSection {
             path: "",
             sortorder: Infinity,
             children: [],
+            visible: true,
         };
     }
 }

--- a/src/navigation/sort-navigation-tree.spec.ts
+++ b/src/navigation/sort-navigation-tree.spec.ts
@@ -37,6 +37,7 @@ it("should sort by manual sort order", () => {
                 sortorder: 3,
             }),
         ],
+        visible: true,
     };
     sortNavigationTree(items);
     expect(items.children).toEqual([
@@ -64,6 +65,7 @@ it("should sort entries with same sortorder by title", () => {
                 sortorder: 1,
             }),
         ],
+        visible: true,
     };
     sortNavigationTree(items);
     expect(items.children).toEqual([
@@ -91,6 +93,7 @@ it("should handle Infinity", () => {
                 sortorder: 1,
             }),
         ],
+        visible: true,
     };
     sortNavigationTree(items);
     expect(items.children).toEqual([

--- a/src/processors/topnav-processor.spec.ts
+++ b/src/processors/topnav-processor.spec.ts
@@ -14,6 +14,7 @@ it("should generate navigation nodes for each entry", () => {
             path: "./foo",
             sortorder: 0,
             children: [],
+            visible: true,
         },
         {
             key: "bar",
@@ -21,6 +22,25 @@ it("should generate navigation nodes for each entry", () => {
             path: "./bar",
             sortorder: 1,
             children: [],
+            visible: true,
+        },
+    ]);
+});
+
+it("should override properties", () => {
+    expect.assertions(1);
+    const entries: TopnavEntry[] = [
+        { path: "./foo", title: "Foo", sortorder: 1, visible: false },
+    ];
+    const rootNode = generateNavigation(entries);
+    expect(rootNode.children).toEqual([
+        {
+            key: "foo",
+            title: "Foo",
+            path: "./foo",
+            sortorder: 1,
+            children: [],
+            visible: false,
         },
     ]);
 });

--- a/src/processors/topnav-processor.ts
+++ b/src/processors/topnav-processor.ts
@@ -11,6 +11,8 @@ import { type Processor } from "../processor";
 export interface TopnavEntry {
     path: string;
     title: string;
+    sortorder?: number;
+    visible?: boolean;
 }
 
 /**
@@ -25,6 +27,7 @@ export function generateNavigation(
             key: key,
             sortorder: index,
             children: [],
+            visible: true,
             ...it,
         };
     });
@@ -33,6 +36,7 @@ export function generateNavigation(
         path: "./index.html",
         sortorder: Infinity,
         children,
+        visible: true,
     };
 }
 

--- a/templates/partials/topnav.html
+++ b/templates/partials/topnav.html
@@ -5,10 +5,11 @@
         {% set navPath = nav.path | replace("html", "") %}
         {% set navPath = navPath | replace(".", "") %}
         {% set activePage = navPath in doc.fileInfo.fullPath %}
+        {% if nav.visible %}
         <li class="docs-topnav__item {% if activePage %}highlight{% endif %}">
             <a class="docs-topnav__anchor" href="{{ nav.path | relative(doc) }}"> {{ nav.title }} </a>
         </li>
-        {%- endfor -%}
+        {% endif %} {%- endfor -%}
         <li class="docs-topnav__item docs-topnav__item--more" style="visibility: hidden">
             <button type="button" class="docs-topnav__anchor" aria-expanded="false">
                 <span>Mer</span>
@@ -23,10 +24,11 @@
                     {% set navPath = nav.path | replace("html", "") %}
                     {% set navPath = navPath | replace(".", "") %}
                     {% set activePage = navPath in doc.fileInfo.fullPath %}
+                    {% if nav.visible %}
                     <li class="docs-contextmenu__item {% if activePage %}highlight{% endif %}" style="display: none">
                         <a class="docs-contextmenu__anchor" href="{{ nav.path | relative(doc) }}"> {{ nav.title }} </a>
                     </li>
-                    {%- endfor -%}
+                    {% endif %} {%- endfor -%}
                 </ul>
             </div>
         </li>


### PR DESCRIPTION
Navigeringsrättningen ska brytas ut till egen PR. Resten är för att visa hur tabellen beter sig.