### PR TITLE
fix: build examples in development mode

### DIFF
--- a/src/compile-example.ts
+++ b/src/compile-example.ts
@@ -42,6 +42,7 @@ async function compileExample(batch: ExampleBatch): Promise<void> {
             external,
             tsconfig,
             define: {
+                "process.env.NODE_ENV": JSON.stringify("development"),
                 "process.env.DOCS_ICON_LIB": JSON.stringify(iconLib),
             },
             plugins: [

--- a/src/vendor/compile-vendor.ts
+++ b/src/vendor/compile-vendor.ts
@@ -93,9 +93,10 @@ export async function compileVendor(
         platform: "browser",
         tsconfig,
         define: {
-            "process.env.NODE_ENV": JSON.stringify(
-                process.env.NODE_ENV ?? "production",
-            ),
+            "process.env.NODE_ENV": JSON.stringify("development"),
+            __VUE_OPTIONS_API__: "true",
+            __VUE_PROD_DEVTOOLS__: "true",
+            __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "false",
         },
         alias: vendor.alias
             ? { [`${vendor.package}`]: vendor.alias }


### PR DESCRIPTION
Så fungerar prop validation osv som det ska.

Och så här blir det i FKUI:

![image](https://github.com/user-attachments/assets/a06b8301-0a54-4f94-9791-b27c0a96c954)
