### PR TITLE
PR 3/4: new extractExamplesProcessor (compilable and lintable examples)

### DIFF
--- a/docs/processors/extract-examples.md
+++ b/docs/processors/extract-examples.md
@@ -1,0 +1,66 @@
+---
+name: Extract examples
+layout: article
+---
+
+The `extractExamplesProcessor` extracts the content from each example and saves to a directory.
+This is used to further process examples with tooling such as linting and compilation.
+
+Given `docs/foo/bar.md` with:
+
+````md
+```ts
+const x = "foo";
+const y = x + 1;
+```
+````
+
+The example will generate the file:
+
+```
+${outputFolder}/docs/foo/bar.md/example-1.ts
+```
+
+If the markdown code fence contains either of the two tags `nocompile` or `nolint` it will be added to the filename:
+
+````md
+```ts nocompile
+const x = "foo";
+const y = x + 1;
+```
+````
+
+The filename will then be:
+
+```
+${outputFolder}/docs/foo/bar.md/example-1-nocompile.ts
+```
+
+This can be used to exclude the file from compilation or linting.
+
+## Usage
+
+```ts
+const docs = new Generator({
+    processors: [
+        extractExamplesProcessor({
+            outputFolder: "docs/examples/files",
+        }),
+    ],
+});
+```
+
+## Configuration
+
+`outputFolder: string`
+: Folder to write examples to. The output folder would typically be git ignored except for configuration files such as `tsconfig.json`.
+
+`languages: string[]` {@optional}
+: Array of languages to extract.
+
+    Default:
+
+    - `"javascript"
+    - `"typescript"`
+    - `"css"`
+    - `"scss"`

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -36,6 +36,7 @@ navigation/sorted-group/sorted-page-2.html
 navigation/sorted-group/sorted-page-3.html
 navigation/sorted-group/top-page.html
 processors/cookie.html
+processors/extract-examples.html
 processors/index.html
 processors/manifest.html
 processors/motd.html

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -65,6 +65,17 @@ export interface DocumentOutlineEntry {
     title: string;
 }
 
+// @public
+export interface ExtractExamplesOptions extends ProcessorOptions {
+    // (undocumented)
+    languages?: string[];
+    // (undocumented)
+    outputFolder: string;
+}
+
+// @public
+export function extractExamplesProcessor(options: ExtractExamplesOptions): Processor;
+
 // @public (undocumented)
 export interface FileInfo {
     fullPath: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,12 +48,14 @@ export {
 export { processorRuntimeName } from "./processor-runtime-name";
 export { type ProcessorStage } from "./processor-stage";
 export {
+    type ExtractExamplesOptions,
     type ManifestProcessorOptions,
     type MOTDOptions,
     type TopnavEntry,
     type VersionProcessorOptions,
     type SelectableVersionProcessorOptions,
     type SourceUrlProcessorOptions,
+    extractExamplesProcessor,
     htmlRedirectProcessor,
     manifestProcessor,
     motdProcessor,

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -266,6 +266,13 @@ exports[`smoketest 1`] = `
         },
         {
           "external": false,
+          "id": "fs:docs/processors/extract-examples.md",
+          "path": "./processors/extract-examples.html",
+          "sortorder": Infinity,
+          "title": "Extract examples",
+        },
+        {
+          "external": false,
           "id": "fs:docs/processors/manifest.md",
           "path": "./processors/manifest.html",
           "sortorder": Infinity,

--- a/src/processors/extract-examples-processor.ts
+++ b/src/processors/extract-examples-processor.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises";
+import path from "node:path/posix";
+import markdownIt from "markdown-it";
+import { type Document } from "../document";
+import { ProcessorOptions, type Processor } from "../processor";
+import { haveOutput, normalizePath } from "../utils";
+import { parseInfostring } from "../examples";
+
+/**
+ * Options for `extractExamplesProcessor`.
+ *
+ * @public
+ */
+export interface ExtractExamplesOptions extends ProcessorOptions {
+    outputFolder: string;
+    languages?: string[];
+}
+
+interface Example {
+    content: string;
+    language: string;
+    tags: string[];
+}
+
+type DocumentWithOutput = Document & { fileInfo: { outputName: string } };
+type DocumentLike = Pick<DocumentWithOutput, "fileInfo" | "body" | "format">;
+
+const md = markdownIt();
+
+md.renderer.rules.fence = (tokens, idx, _options, collected: Example[]) => {
+    const { content, info } = tokens[idx];
+    const { language, tags } = parseInfostring(info);
+
+    if (language === "import") {
+        return "";
+    }
+
+    collected.push({
+        content,
+        language,
+        tags,
+    });
+
+    return "";
+};
+
+function findExamples(doc: DocumentLike): Example[] {
+    if (doc.format !== "markdown") {
+        return [];
+    }
+    const collected: Example[] = [];
+    md.render(doc.body, collected);
+    return collected;
+}
+
+function getSuffix(tags: string[]): string {
+    const relevant = tags.filter((it) => ["nocompile", "nolint"].includes(it));
+    if (relevant.length > 0) {
+        return `-${relevant.join("-")}`;
+    } else {
+        return "";
+    }
+}
+
+function getExtension(lang: string): string {
+    switch (lang) {
+        case "typescript":
+            return "ts";
+        case "javascript":
+            return "js";
+        default:
+            return lang;
+    }
+}
+
+/**
+ * Processor to extract and write examples to separate files.
+ *
+ * @public
+ */
+export function extractExamplesProcessor(
+    options: ExtractExamplesOptions,
+): Processor {
+    const {
+        enabled = true,
+        outputFolder,
+        languages = ["javascript", "typescript", "css", "scss"],
+    } = options;
+
+    function isRelevant(example: Example): boolean {
+        return languages.includes(example.language);
+    }
+
+    return {
+        stage: "render",
+        name: "extract-examples-processor",
+        async handler(context) {
+            if (!enabled) {
+                return;
+            }
+
+            if (!outputFolder) {
+                throw new Error(
+                    `"outputFolder" not set in "extractExamplesProcessor(..)"`,
+                );
+            }
+
+            /* clear old folder to remove potential obsolete files */
+            await fs.rm(outputFolder, { recursive: true, force: true });
+
+            let total = 0;
+            for (const doc of context.docs.filter(haveOutput)) {
+                const examples = findExamples(doc).filter(isRelevant);
+                if (examples.length === 0) {
+                    continue;
+                }
+
+                /* create a directory matching the filename the examples is contained in */
+                const dir = normalizePath(outputFolder, doc.fileInfo.fullPath);
+                await fs.mkdir(dir, { recursive: true });
+
+                /* write each example into the directory */
+                let n = 1;
+                for (const example of examples) {
+                    const suffix = getSuffix(example.tags);
+                    const extension = getExtension(example.language);
+                    const filename = `example-${String(n++)}${suffix}.${extension}`;
+                    const filePath = path.join(dir, filename);
+                    await fs.writeFile(filePath, example.content, "utf-8");
+                    total++;
+                }
+            }
+
+            context.log(total, "examples extracted");
+        },
+    };
+}

--- a/src/processors/index.ts
+++ b/src/processors/index.ts
@@ -1,4 +1,8 @@
 export {
+    type ExtractExamplesOptions,
+    extractExamplesProcessor,
+} from "./extract-examples-processor";
+export {
     type ManifestProcessorOptions,
     manifestProcessor,
 } from "./manifest-processor";


### PR DESCRIPTION
Låter oss extrahera ut exempel till separata filer så man lättare kan kompilera och linta filerna.

Givet `docs/foo/bar.md` med:

````md
```ts
const x = "foo";
const y = x + 1;
```
````

Och konfigurationen:

```ts
extractExamplesProcessor({
    output: "docs/examples",
});
```

Så får man:

```
docs/examples/docs/foo/bar.md/example-1.ts
```

Den filen man kan sen linta och kompilera.

Gör man det i FKUI så får man:

* 39st eslint fel (efter att jag stängt av regler som `no-console`, `no-unused-vars` osv)
* ~69st~ kompileringsfel (en del exempel har rätt så allvarliga typos). **EDIT:** Om man fixar de 69 felen som är så allvarliga att `tsc` ballar ur helt så får man ca 250st nya fel :partying_face: 

Rekommenderar att läsa PRs i omvänd ordning, dvs börja med PR 4 och ta det därifrån. De mergas däremot i denna ordningen.