### PR TITLE
PR 2/4: source code stripping (compilable and lintable examples)

### DIFF
--- a/docs/markdown/code-preview/code-preview.md
+++ b/docs/markdown/code-preview/code-preview.md
@@ -89,6 +89,40 @@ function foo(value) {
 }
 ```
 
+The source code may also contains snippets which are cut from the rendered source code.
+
+This is mostly useful in combination with extracting the example source code and running external tools, e.g. compiling the example might require additional imports or declarations.
+
+**Input:**
+
+````md
+```ts
+declare function add(a: number, b: number): number;
+
+/* --- cut above --- */
+
+const result = add(1, 2);
+```
+````
+
+**Output:**
+
+```ts
+declare function add(a: number, b: number): number;
+
+/* --- cut above --- */
+
+const result = add(1, 2);
+```
+
+The following instructions are available:
+
+-   `/* --- cut above --- */` removes all lines above the instruction.
+-   `/* --- cut below --- */` removes all lines below the instruction.
+-   `/* --- cut begin --- */` and `/* --- cut end --- */` removes all lines between the two instructions.
+
+Blank lines above or below the instructions will always be trimmed as well.
+
 ## Importing files
 
 Instead of writing examples inline the source can be imported from another file.

--- a/docs/markdown/code-preview/code-preview.md
+++ b/docs/markdown/code-preview/code-preview.md
@@ -67,6 +67,28 @@ export interface Foo {
 }
 ```
 
+ESLint comments will be stripped from the rendered source code.
+
+**Input:**
+
+````md
+```js
+function foo(value) {
+    /* eslint-disable-next-line eqeqeq */
+    return value == "foo";
+}
+```
+````
+
+**Output:**
+
+```js
+function foo(value) {
+    /* eslint-disable-next-line eqeqeq */
+    return value == "foo";
+}
+```
+
 ## Importing files
 
 Instead of writing examples inline the source can be imported from another file.

--- a/docs/markdown/code-preview/code-preview.md
+++ b/docs/markdown/code-preview/code-preview.md
@@ -1,6 +1,6 @@
 ---
 title: Code preview
-layout: content-with-menu
+layout: article
 ---
 
 Code within markdown code fences will be rendered with syntax highlighting and for languages that can run in the browser a runnable example will be created.
@@ -47,7 +47,9 @@ HTML is rendered in the browser and the HTML markup is shown with syntax highlig
 
 ### Javascript / Typescript
 
-Javascript and typescript only shows the code with syntax highlight.
+Javascript and Typescript only shows the code with syntax highlight.
+
+See also {@link javascript Javascript and Typescript} for additional details about wrinting JS-based examples.
 
 **Input:**
 
@@ -66,62 +68,6 @@ export interface Foo {
     name: string;
 }
 ```
-
-ESLint comments will be stripped from the rendered source code.
-
-**Input:**
-
-````md
-```js
-function foo(value) {
-    /* eslint-disable-next-line eqeqeq */
-    return value == "foo";
-}
-```
-````
-
-**Output:**
-
-```js
-function foo(value) {
-    /* eslint-disable-next-line eqeqeq */
-    return value == "foo";
-}
-```
-
-The source code may also contains snippets which are cut from the rendered source code.
-
-This is mostly useful in combination with extracting the example source code and running external tools, e.g. compiling the example might require additional imports or declarations.
-
-**Input:**
-
-````md
-```ts
-declare function add(a: number, b: number): number;
-
-/* --- cut above --- */
-
-const result = add(1, 2);
-```
-````
-
-**Output:**
-
-```ts
-declare function add(a: number, b: number): number;
-
-/* --- cut above --- */
-
-const result = add(1, 2);
-```
-
-The following instructions are available:
-
--   `/* --- cut above --- */` removes all lines above the instruction.
--   `/* --- cut below --- */` removes all lines below the instruction.
--   `/* --- cut begin --- */` and `/* --- cut end --- */` removes all lines between the two instructions.
-
-Blank lines above or below the instructions will always be trimmed as well.
 
 ## Importing files
 

--- a/docs/markdown/code-preview/javascript.md
+++ b/docs/markdown/code-preview/javascript.md
@@ -1,0 +1,84 @@
+---
+title: Javascript and Typescript
+layout: article
+---
+
+Javascript and Typescript only shows the code with syntax highlight.
+
+**Input:**
+
+````md
+```ts
+export interface Foo {
+    name: string;
+}
+```
+````
+
+**Output:**
+
+```ts
+export interface Foo {
+    name: string;
+}
+```
+
+## ESLint
+
+ESLint comments will be stripped from the rendered source code.
+
+**Input:**
+
+````md
+```js
+function foo(value) {
+    /* eslint-disable-next-line eqeqeq */
+    return value == "foo";
+}
+```
+````
+
+**Output:**
+
+```js
+function foo(value) {
+    /* eslint-disable-next-line eqeqeq */
+    return value == "foo";
+}
+```
+
+## Snippets
+
+The source code may also contains snippets which are cut from the rendered source code.
+
+This is mostly useful in combination with extracting the example source code and running external tools, e.g. compiling the example might require additional imports or declarations.
+
+**Input:**
+
+````md
+```ts
+declare function add(a: number, b: number): number;
+
+/* --- cut above --- */
+
+const result = add(1, 2);
+```
+````
+
+**Output:**
+
+```ts
+declare function add(a: number, b: number): number;
+
+/* --- cut above --- */
+
+const result = add(1, 2);
+```
+
+The following instructions are available:
+
+-   `/* --- cut above --- */` removes all lines above the instruction.
+-   `/* --- cut below --- */` removes all lines below the instruction.
+-   `/* --- cut begin --- */` and `/* --- cut end --- */` removes all lines between the two instructions.
+
+Blank lines above or below the instructions will always be trimmed as well.

--- a/docs/processors/version.md
+++ b/docs/processors/version.md
@@ -11,6 +11,11 @@ layout: content-with-menu
 const pkg = JSON.parse(await fs.readFile("package.json", "utf-8"));
 
 const docs = new Generator({
+    site: { name: ".." },
+    outputFolder: "..",
+    cacheFolder: "..",
+    exampleFolders: [],
+
     processors: [versionProcessor(pkg, "footer:right")],
 });
 ```

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -15,6 +15,7 @@ live-example/example.html
 live-example/index.html
 markdown/code-preview/fullscreen.html
 markdown/code-preview/index.html
+markdown/code-preview/javascript.html
 markdown/code-preview/vue.html
 markdown/containers/alt-text.html
 markdown/containers/details.html

--- a/src/examples/generate-example.ts
+++ b/src/examples/generate-example.ts
@@ -6,6 +6,7 @@ import { type ExampleOptions } from "./example-options";
 import { type ExampleResult } from "./example-result";
 import { getExampleImport } from "./get-example-import";
 import { getExampleName } from "./get-example-name";
+import { transformCode } from "./transform-code";
 
 const vueMajor = parseInt(version.split(".", 2)[0], 10) as 2 | 3;
 
@@ -32,9 +33,10 @@ export function generateExample(options: ExampleOptions): ExampleResult {
             options.exampleFolders,
             parsed.filename,
         );
-        const source = fs.readFileSync(filename, "utf-8");
         const language = parsed.extension;
         const comments = parsed.comments;
+        const content = fs.readFileSync(filename, "utf-8");
+        const source = transformCode(content, language);
         const example = generateExample({
             ...options,
             source,

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -12,3 +12,4 @@ export {
 export { generateExample } from "./generate-example";
 export { getExampleImport } from "./get-example-import";
 export { parseInfostring } from "./parse-infostring";
+export { transformCode } from "./transform-code";

--- a/src/examples/transform-code.spec.ts
+++ b/src/examples/transform-code.spec.ts
@@ -1,0 +1,81 @@
+import dedent from "dedent";
+import { transformCode } from "./transform-code";
+
+expect.addSnapshotSerializer({
+    test() {
+        return true;
+    },
+    serialize(value: string) {
+        return value;
+    },
+});
+
+it("should retain newlines", () => {
+    expect.assertions(6);
+    expect(transformCode("", "javascript")).toBe("");
+    expect(transformCode("\n", "javascript")).toBe("\n");
+    expect(transformCode("\n\n", "javascript")).toBe("\n\n");
+    expect(transformCode("a\nb", "javascript")).toBe("a\nb");
+    expect(transformCode("a\nb\n", "javascript")).toBe("a\nb\n");
+    expect(transformCode("a\nb\n\n", "javascript")).toBe("a\nb\n\n");
+});
+
+it("should ignore other languages", () => {
+    expect.assertions(3);
+    expect(transformCode("/* eslint-disable foo */", "javascript")).toBe("");
+    expect(transformCode("/* eslint-disable foo */", "typescript")).toBe("");
+    expect(transformCode("/* eslint-disable foo */", "plaintext")).toBe(
+        "/* eslint-disable foo */",
+    );
+});
+
+it("should remove eslint /* .. */ comments", () => {
+    expect.assertions(1);
+    const source = dedent`
+        const foo = 1;
+        /* regular comment */
+        const bar = /* eslint-disable foo */ 2;
+        /* eslint-disable foo -- bar */
+        /* eslint-disable-next-line foo -- bar */
+        const baz = 3; /* eslint-disable-line foo -- bar */
+
+        function foo(value) {
+            /* eslint-disable-next-line eqeqeq */
+            return value == "foo";
+        }
+    `;
+    expect(transformCode(source, "javascript")).toMatchInlineSnapshot(`
+        const foo = 1;
+        /* regular comment */
+        const bar = 2;
+        const baz = 3;
+
+        function foo(value) {
+            return value == "foo";
+        }
+    `);
+});
+
+it("should remove eslint // comments", () => {
+    expect.assertions(1);
+    const source = dedent`
+        const foo = 1; // regular comment
+        // eslint-disable foo
+        // eslint-disable foo -- bar
+        // eslint-disable-next-line foo -- bar
+        const bar = 2; // eslint-disable-line foo -- bar
+
+        function foo(value) {
+            // eslint-disable-next-line eqeqeq
+            return value == "foo";
+        }
+    `;
+    expect(transformCode(source, "javascript")).toMatchInlineSnapshot(`
+        const foo = 1; // regular comment
+        const bar = 2;
+
+        function foo(value) {
+            return value == "foo";
+        }
+    `);
+});

--- a/src/examples/transform-code.spec.ts
+++ b/src/examples/transform-code.spec.ts
@@ -79,3 +79,145 @@ it("should remove eslint // comments", () => {
         }
     `);
 });
+
+it("should cut above marker", () => {
+    expect.assertions(1);
+    const source = dedent`
+        a
+        b
+        /* --- cut above --- */
+        c
+        d
+    `;
+    expect(transformCode(source, "typescript")).toMatchInlineSnapshot(`
+        c
+        d
+    `);
+});
+
+it("should cut above marker with surrounding newlines", () => {
+    expect.assertions(1);
+    const source = dedent`
+        a
+        b
+
+        /* --- cut above --- */
+
+        c
+        d
+    `;
+    expect(transformCode(source, "typescript")).toMatchInlineSnapshot(`
+        c
+        d
+    `);
+});
+
+it("should cut below marker", () => {
+    expect.assertions(1);
+    const source = dedent`
+        a
+        b
+        /* --- cut below --- */
+        c
+        d
+    `;
+    expect(transformCode(source, "typescript")).toMatchInlineSnapshot(`
+        a
+        b
+    `);
+});
+
+it("should cut below marker with surrounding newlines", () => {
+    expect.assertions(1);
+    const source = dedent`
+        a
+        b
+
+        /* --- cut below --- */
+
+        c
+        d
+    `;
+    expect(transformCode(source, "typescript")).toMatchInlineSnapshot(`
+        a
+        b
+    `);
+});
+
+it("should cut with start and end marker", () => {
+    expect.assertions(1);
+    const source = dedent`
+        a
+        /* --- cut begin --- */
+        b
+        /* --- cut end --- */
+        c
+    `;
+    expect(transformCode(source, "typescript")).toMatchInlineSnapshot(`
+        a
+        c
+    `);
+});
+
+it("should cut with start and end marker with surrounding newlines", () => {
+    expect.assertions(1);
+    const source = dedent`
+        a
+
+        /* --- cut begin --- */
+        b
+        /* --- cut end --- */
+
+        c
+    `;
+    expect(transformCode(source, "typescript")).toMatchInlineSnapshot(`
+        a
+        c
+    `);
+});
+
+it("should handle missing end instruction same as cut below", () => {
+    expect.assertions(1);
+    const source = dedent`
+        a
+        b
+
+        /* --- cut begin --- */
+
+        c
+        d
+    `;
+    expect(transformCode(source, "typescript")).toMatchInlineSnapshot(`
+        a
+        b
+    `);
+});
+
+it("should handle missing begin instruction same as cut above", () => {
+    expect.assertions(1);
+    const source = dedent`
+        a
+        b
+
+        /* --- cut end --- */
+
+        c
+        d
+    `;
+    expect(transformCode(source, "typescript")).toMatchInlineSnapshot(`
+        c
+        d
+    `);
+});
+
+it("should handle cuts with no other content", () => {
+    expect.assertions(3);
+    expect(transformCode("/* --- cut above --- */", "javascript")).toBe("");
+    expect(transformCode("/* --- cut below --- */", "javascript")).toBe("");
+    expect(
+        transformCode(
+            "/* --- cut begin --- */\n/* --- cut end --- */",
+            "javascript",
+        ),
+    ).toBe("");
+});

--- a/src/examples/transform-code.ts
+++ b/src/examples/transform-code.ts
@@ -1,3 +1,95 @@
+function removeLinesInline(
+    lines: string[],
+    { begin, end }: { begin: number; end: number },
+): void {
+    /* remove lines by blanking them (when the lines are later joined these
+     * blank lines end up being nothing */
+    for (let i = begin; i <= end; i++) {
+        lines[i] = "";
+    }
+
+    /* if the previous line is just a blank line we remove that as well */
+    if (lines[begin - 1] === "\n") {
+        lines[begin - 1] = "";
+        begin--;
+    }
+
+    /* if the next line is just a blank line we remove that as well */
+    if (lines[end + 1] === "\n") {
+        lines[end + 1] = "";
+    }
+
+    /* remove the trailing newline from the new last line or we end up with an
+     * extra newline at the end of the string that wasn't there before */
+    if (end === lines.length - 1 && begin > 0) {
+        lines[begin - 1] = lines[begin - 1].slice(0, -1);
+    }
+}
+
+function cutSnippets(code: string): string {
+    const lines = code
+        .split(/\n/)
+        .map((it, index, lines) => (index < lines.length - 1 ? `${it}\n` : it));
+    const directive = /\/\* +--- +cut (above|below|begin|end) +--- +\*\//;
+
+    let buffer = -1;
+    lines.forEach((line, index) => {
+        const match = line.match(directive);
+        const [, instruction] = match ?? ["", null];
+        if (!instruction) {
+            return;
+        }
+        switch (instruction) {
+            /* --- cut above --- */
+            case "above":
+                /* remove all lines above (including this one) */
+                removeLinesInline(lines, {
+                    begin: 0,
+                    end: index,
+                });
+                break;
+            /* --- cut below --- */
+            case "below":
+                /* remove all lines below (including this one) */
+                removeLinesInline(lines, {
+                    begin: index,
+                    end: lines.length - 1,
+                });
+                break;
+            /* --- cut begin --- */
+            case "begin":
+                /* here we only hold on to the line number until we
+                 * encounter the end instruction */
+                if (buffer === -1) {
+                    buffer = index;
+                }
+                break;
+            /* --- cut end --- */
+            case "end":
+                removeLinesInline(lines, {
+                    begin: Math.max(buffer, 0),
+                    end: index,
+                });
+                buffer = -1;
+                break;
+            default:
+                break;
+        }
+    });
+
+    /* if cut begin was used without end we still have the line number buffered
+     * and should interpret it as cut below, i.e. we remove all lines from begin
+     * and down */
+    if (buffer >= 0) {
+        removeLinesInline(lines, {
+            begin: buffer,
+            end: lines.length - 1,
+        });
+    }
+
+    return lines.join("");
+}
+
 function stripEslintComments(code: string): string {
     /* matches an eslint comment occupying the whole line (entire line including
      * newline is removed) */
@@ -14,8 +106,8 @@ function stripEslintComments(code: string): string {
 
 /* transformations to apply based on language, transforms are run from left to right */
 const transformations: Record<string, Array<(code: string) => string>> = {
-    javascript: [stripEslintComments],
-    typescript: [stripEslintComments],
+    javascript: [cutSnippets, stripEslintComments],
+    typescript: [cutSnippets, stripEslintComments],
 };
 
 export function transformCode(code: string, lang: string): string {

--- a/src/examples/transform-code.ts
+++ b/src/examples/transform-code.ts
@@ -1,0 +1,27 @@
+function stripEslintComments(code: string): string {
+    /* matches an eslint comment occupying the whole line (entire line including
+     * newline is removed) */
+    const matchLine =
+        /^[ \t]*(\/\* eslint-disable[^*]*\*\/|\/\/ eslint-disable.*)\n/gm;
+
+    /* matches an eslint comment embedded with other statements (only the
+     * commend and whitespace before it is removed) */
+    const matchEmbedded =
+        /[ \t]*(\/\* eslint-disable[^*]*\*\/|\/\/ eslint-disable.*)/g;
+
+    return code.replace(matchLine, "").replace(matchEmbedded, "");
+}
+
+/* transformations to apply based on language, transforms are run from left to right */
+const transformations: Record<string, Array<(code: string) => string>> = {
+    javascript: [stripEslintComments],
+    typescript: [stripEslintComments],
+};
+
+export function transformCode(code: string, lang: string): string {
+    const fns = transformations[lang] ?? [];
+    for (const fn of fns) {
+        code = fn(code);
+    }
+    return code;
+}

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -30,6 +30,13 @@ exports[`smoketest 1`] = `
             },
             {
               "external": false,
+              "id": "fs:docs/markdown/code-preview/javascript.md",
+              "path": "./markdown/code-preview/javascript.html",
+              "sortorder": Infinity,
+              "title": "Javascript and Typescript",
+            },
+            {
+              "external": false,
               "id": "fs:docs/markdown/code-preview/vue.md",
               "path": "./markdown/code-preview/vue.html",
               "sortorder": Infinity,

--- a/src/render/markdown/code-preview.ts
+++ b/src/render/markdown/code-preview.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import type MarkdownIt from "markdown-it";
-import { type ExampleResult, parseInfostring } from "../../examples";
+import {
+    type ExampleResult,
+    parseInfostring,
+    transformCode,
+} from "../../examples";
 import { type MarkdownEnv } from "../markdown-env";
 import { getFingerprint } from "../../utils";
 import { findTestId, highlight, htmlencode, replaceAtLink } from "./utils";
@@ -50,14 +54,16 @@ export function codePreview(
         env: MarkdownEnv,
     ): string {
         const { fileInfo } = env;
-        const { content: source, info, map } = tokens[idx];
+        const { content: rawSource, info, map } = tokens[idx];
         const { language, tags: rawTags } = parseInfostring(info);
 
         if (language === "mermaid") {
             return /* HTML */ `
-                <pre class="mermaid">${htmlencode(source)}</pre>
+                <pre class="mermaid">${htmlencode(rawSource)}</pre>
             `;
         }
+
+        const source = transformCode(rawSource, language);
 
         const example = generateExample({
             source,


### PR DESCRIPTION
Möjliggör att man strippar bort delar av exempelkoden från vad som syns för läsaren:

````md
```ts
import { Foobar } from "foobar";

/* --- cut above --- */

const foobar = new Foobar();
```
````

Det som syns när det renderas sen ("Visa kod"):

```ts
const foobar = new Foobar();
```

Även eslint kommentarer strippas bort så om man behöver kan man köra `/* eslint-disable foobar */` utan att det syns för läsaren.

Syftet är att kunna kompilera och linta exempel utan att alltid behöva visa alla stegen. Exempelvis kan importen av `Foobar` ovan vara överflödig men behövs för att kunna kompilera.

Rekommenderar att läsa PRs i omvänd ordning, dvs börja med PR 4 och ta det därifrån. De mergas däremot i denna ordningen.