### PR TITLE
fix: more readable and usable error message when a render error occurs

### DIFF
--- a/internal/plugin-vue3/src/generate-code.ts
+++ b/internal/plugin-vue3/src/generate-code.ts
@@ -35,8 +35,11 @@ export function generateCode(options: ExampleOptions): ExampleResult {
     const { descriptor, errors } = parse(code, { filename });
     const scopeId = `data-v-${fingerprint}`;
 
-    if (errors.length) {
-        throw new Error(`Errors occured when trying to parse ${filename}.`);
+    if (errors.length > 0) {
+        const first = errors[0].message;
+        throw new Error(
+            `Errors occured when trying to parse "${filename}": ${first}`,
+        );
     }
 
     const hasScoped = descriptor.styles.some((e) => e.scoped);

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -26,6 +26,7 @@ import { TemplateLoader } from "./template-loader";
 import * as filter from "./filter";
 import { findTemplate } from "./find-template";
 import { createMarkdownRenderer } from "./create-markdown-renderer";
+import { TemplateRenderError } from "./template-render-error";
 
 interface ActiveNavigationLeaf extends NavigationLeaf {
     active: boolean;
@@ -328,7 +329,12 @@ export async function render(
     try {
         content = await renderTemplate(template, templateData);
     } catch (err: unknown) {
-        const prefix = `Failed to render "${fileInfo.fullPath}"`;
+        const filename = fileInfo.fullPath;
+        if (err instanceof Error && err.name === "Template render error") {
+            /* recreate nunjucks template errors to be a bit more useful and readable */
+            throw new TemplateRenderError(err.message, filename);
+        }
+        const prefix = `Failed to render "${filename}"`;
         const message = err instanceof Error ? err.message : String(err);
         throw new Error(`${prefix}: ${message}`, { cause: err });
     }

--- a/src/render/template-render-error.spec.ts
+++ b/src/render/template-render-error.spec.ts
@@ -1,0 +1,18 @@
+import { getActualMessage } from "./template-render-error";
+
+it("should extract actual error from nunjucks error", () => {
+    expect.assertions(1);
+    const error = [
+        "(/path/to/template.html) [Line 8, Column 3]",
+        "  Error: lorem ipsum dolor sit amet",
+    ].join("\n");
+    const result = getActualMessage(error);
+    expect(result).toBe("lorem ipsum dolor sit amet");
+});
+
+it("should return original message if it cannot be matched", () => {
+    expect.assertions(1);
+    const error = ["lorem ipsum dolor sit amet"].join("\n");
+    const result = getActualMessage(error);
+    expect(result).toBe("lorem ipsum dolor sit amet");
+});

--- a/src/render/template-render-error.ts
+++ b/src/render/template-render-error.ts
@@ -1,0 +1,39 @@
+const messageRegex = /^[(][^)]+[)] \[Line \d+, Column \d+\]\n\s+Error: (.*)$/;
+
+/**
+ * Extracts the actual error message from a nunjucks render error.
+ *
+ * The error instance should have properties such as `.cause` but these are lost
+ * somewhere so this serves as a workaround.
+ *
+ * @internal
+ */
+export function getActualMessage(message: string): string {
+    const match = message.match(messageRegex);
+    if (match) {
+        return match[1].trim();
+    } else {
+        return message;
+    }
+}
+
+/**
+ * @internal
+ */
+export class TemplateRenderError extends Error {
+    private readonly filename: string;
+
+    public constructor(message: string, filename: string) {
+        super(getActualMessage(message));
+        this.name = "RenderError";
+        this.filename = filename;
+    }
+
+    public prettyError(): string {
+        return [
+            `An error occured when rendering a document.`,
+            `  Document: "${this.filename}".`,
+            `  Message: ${this.message}`,
+        ].join("\n");
+    }
+}


### PR DESCRIPTION
Den här ändringen gör inget mer än att göra fel från rendering mer begripliga genom att ta bort allt brus. Man ser inte längre vilken mall (och vilken rad/kolumn i mallen) men personligen tycker jag det är irrelevant (men ni behöver inte hålla med)

**Från**:

```
When running processor "nunjucks-renderer":
Error: Failed to render "docs/functions/cypress/pageobjects/FProgressbarPageObject/FProgressbarPageObject-progress-status.md": (/path/to/project/node_modules/@forsakringskassan/docs-generator/templates/article.template.html) [Line 8, Column 3]
  Error: Errors occured when trying to parse docs/functions/cypress/pageobjects/FProgressbarPageObject/FProgressbarPageObject-progress-status.vue.
    at render (/path/to/project/node_modules/@forsakringskassan/docs-generator/dist/index.js:2020:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Object.handler (/path/to/project/node_modules/@forsakringskassan/docs-generator/dist/index.js:2101:28)
    at async stage (/path/to/project/node_modules/@forsakringskassan/docs-generator/dist/index.js:2380:22)
    at async Generator.build (/path/to/project/node_modules/@forsakringskassan/docs-generator/dist/index.js:2622:7)
    at async file:///path/to/project/generate-docs.mjs:160:5 {
  [cause]: Template render error: (/path/to/project/node_modules/@forsakringskassan/docs-generator/templates/article.template.html) [Line 8, Column 3]
    Error: Errors occured when trying to parse docs/functions/cypress/pageobjects/FProgressbarPageObject/FProgressbarPageObject-progress-status.vue.
      at Object._prettifyError (/path/to/project/node_modules/nunjucks/src/lib.js:32:11)
      at /path/to/project/node_modules/nunjucks/src/environment.js:464:19
      at eval (eval at _compile (/path/to/project/node_modules/nunjucks/src/environment.js:527:18), <anonymous>:199:12)
      at b_content (eval at _compile (/path/to/project/node_modules/nunjucks/src/environment.js:527:18), <anonymous>:69:3)
      at eval (eval at _compile (/path/to/project/node_modules/nunjucks/src/environment.js:527:18), <anonymous>:198:86)
      at b_sidenav (eval at _compile (/path/to/project/node_modules/nunjucks/src/environment.js:527:18), <anonymous>:53:1)
      at eval (eval at _compile (/path/to/project/node_modules/nunjucks/src/environment.js:527:18), <anonymous>:104:86)
      at eval (eval at _compile (/path/to/project/node_modules/nunjucks/src/environment.js:527:18), <anonymous>:100:1)
      at fn (/path/to/project/node_modules/a-sync-waterfall/index.js:26:24)
      at /path/to/project/node_modules/a-sync-waterfall/index.js:66:22
```

**Till**:

```
When running processor "nunjucks-renderer":
An error occured when rendering a document.
  Document: "docs/functions/cypress/pageobjects/FProgressbarPageObject/FProgressbarPageObject-progress-status.md".
  Message: Errors occured when trying to parse docs/functions/cypress/pageobjects/FProgressbarPageObject/FProgressbarPageObject-progress-status.vue.
```

**EDIT**:

La även till att vi visar ursprungsfelet när Vue's compiler inte kan parsa filen så ovan blir då:

```
When running processor "nunjucks-renderer":
An error occured when rendering a document.
  Document: "docs/functions/cypress/pageobjects/FProgressbarPageObject/FProgressbarPageObject-progress-status.md".
  Message: Errors occured when trying to parse "docs/functions/cypress/pageobjects/FProgressbarPageObject/FProgressbarPageObject-progress-status.vue": At least one <template> or <script> is required in a single file component. docs/functions/cypress/pageobjects/FProgressbarPageObject/FProgressbarPageObject-progress-status.vue
```

Nu innehåller alltså Vue's `Error` också filnamnet i slutet så lite kaka på kaka men vet inte om det är värt att massera bort det? Eller det är väl bara en string replace men jag vet inte. Åsikter?