### PR TITLE
fix: show vue compiler errors runtime during local builds

### DIFF
--- a/internal/plugin-vue3/package.json
+++ b/internal/plugin-vue3/package.json
@@ -22,7 +22,8 @@
     "build": "node build.mjs"
   },
   "dependencies": {
-    "esbuild-plugin-vue3": "0.4.2"
+    "esbuild-plugin-vue3": "0.4.2",
+    "is-ci": "4.1.0"
   },
   "devDependencies": {
     "@types/html-minifier": "4.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "esbuild-plugin-vue3": "0.4.2"
+        "esbuild-plugin-vue3": "0.4.2",
+        "is-ci": "4.1.0"
       },
       "devDependencies": {
         "@types/html-minifier": "4.0.5",
@@ -12252,7 +12253,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-4.1.0.tgz",
       "integrity": "sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12271,7 +12271,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
       "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/src/examples/generate-example.ts
+++ b/src/examples/generate-example.ts
@@ -68,21 +68,34 @@ function generateVueExample(options: ExampleOptions): ExampleResult {
         code: source,
         setupPath,
     });
-    return {
-        source,
-        language: options.language,
-        comments: [],
-        tags,
-        markup,
-        output,
-        runtime: true,
-        task: {
-            outputFile: output,
-            sourcecode,
-            sourceFile: filename,
-            parent,
-        },
-    };
+    if (output) {
+        return {
+            source,
+            language: options.language,
+            comments: [],
+            tags,
+            markup,
+            output,
+            runtime: true,
+            task: {
+                outputFile: output,
+                sourcecode,
+                sourceFile: filename,
+                parent,
+            },
+        };
+    } else {
+        return {
+            source: sourcecode,
+            language: "plaintext",
+            comments: [],
+            tags,
+            markup,
+            output: null,
+            runtime: true,
+            task: null,
+        };
+    }
 }
 
 function generateStaticExample(options: ExampleOptions): ExampleResult {


### PR DESCRIPTION
Utökning av #154, om det är ett lokalt bygge (skiljt från CI) så hanteras fel från Vue's compiler och presenteras istället i runtime. Bygger man i CI miljö så får man fel som tidigare, dvs det stoppar bygget.

![image](https://github.com/user-attachments/assets/77f00f72-fca2-46f7-a023-cfb4d00e4271)

Motiveringen är att det ska vara smidigare när man aktivt sitter och skriver dokumentation. Typiskt exempel kan vara om man skapar upp en tom placeholder fil tills vidare men vill bygga och se resultatet av resten man skrivit.