### PR TITLE
fix: correct font-size and text-decoration for code block in heading

### DIFF
--- a/src/style/core.scss
+++ b/src/style/core.scss
@@ -96,6 +96,20 @@ h1 code {
     font-weight: 400;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    code {
+        font-size: inherit;
+        margin: 0;
+        padding: 0;
+        text-decoration: inherit;
+    }
+}
+
 #content a:not(.code-preview a) {
     color: var(--docs-text-color-default);
 }


### PR DESCRIPTION
Fixar font-storlek och understrykning för kod-block i rubriker.

Före:
![{D82B97BC-7992-46D6-8409-050A6F5084FD}](https://github.com/user-attachments/assets/cfaec613-a016-4aa0-9ccf-f95d419f599f)

Efter:
![{D4988264-C716-43D5-918D-F346A28BB1E1}](https://github.com/user-attachments/assets/08e3e709-ba87-4bef-aff9-10bec2b774fb)

Sido effekt, då padding och marginal sätts till 0 så linjerar även rubriker som börjar med ett kod-block korrekt.