### PR TITLE
compileScripts(), esm och importmaps

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,4 @@
+---
+title: Configuration
+layout: article
+---

--- a/docs/configuration/scripts.md
+++ b/docs/configuration/scripts.md
@@ -1,0 +1,38 @@
+---
+title: Scripts
+layout: article
+---
+
+Scripts can be compiled with the bultin `compileScript()` function:
+
+```ts nolint nocompile
+Generator.compileScript(name, src, options, buildOptions);
+```
+
+`name: string`
+: Unique name for this script. Used when referencing the script and as the base of the output filename.
+
+`src: string`
+: Path to the script entrypoint.
+
+`options: CompileOptions` {@optional}
+: Options for this script.
+
+    `appendTo` {@optional}
+    : If and where the script should be injected into the document.
+
+        One of:
+
+    	* `"head"` - a `<script>` tag is automatically injected into `<head>`.
+    	* `"body"` - a `<script>` tag is automatically injected into `<body>`.
+    	* `"none"` - the script is not injected automatically.
+
+    	If the script is not injected it is included in the importmap and can be referenced by other scripts with `import("name")`.
+
+    	Default is `"none"`.
+
+    `attributes: Record<string, unknown>` {@optional}
+    : Extra HTML attributes to set on the `<script>` tag.
+
+    `priority: number` {@optional}
+    : Assets with higher priority is sorted and loaded earlier than assets with lower.

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -4,6 +4,8 @@
 
 ```
 changelog.html
+configuration/index.html
+configuration/scripts.html
 e2e/code-snippets.html
 example/redirect.html -> markdown/redirects.html
 file-reader/vue-file-reader.html

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -301,6 +301,8 @@ export interface ProcessorContext {
     // (undocumented)
     getTemplateData<K extends keyof TemplateData>(key: K): TemplateData[K] | undefined;
     // (undocumented)
+    getTemplateData<K extends keyof TemplateData>(key: K, defaultValue: TemplateData[K]): TemplateData[K];
+    // (undocumented)
     getTemplateData(key: string): unknown;
     // @internal
     hasTemplate(name: string): boolean;

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -297,7 +297,7 @@ export interface ProcessorContext {
     // @internal (undocumented)
     getAllTemplateBlocks(): Map<string, Array<TemplateBlockData<unknown>>>;
     // (undocumented)
-    getAllTemplateData(): Record<string, unknown>;
+    getAllTemplateData(): TemplateData & Record<string, unknown>;
     // (undocumented)
     getTemplateData<K extends keyof TemplateData>(key: K): TemplateData[K] | undefined;
     // (undocumented)

--- a/src/assets/asset-info.ts
+++ b/src/assets/asset-info.ts
@@ -1,6 +1,6 @@
 declare module "../processor-context" {
     export interface TemplateData {
-        assets: Record<string, AssetInfo>;
+        assets: Record<string, AssetInfo & AssetImportmap>;
         injectHead: InjectedAssetInfo[];
         injectBody: InjectedAssetInfo[];
     }
@@ -24,7 +24,18 @@ export interface AssetInfo {
     readonly type: "css" | "js";
 }
 
+/**
+ * @internal
+ */
 export interface InjectedAssetInfo extends AssetInfo {
     /** asset html attributes (serialized as `key="value"` already) */
     readonly attrs: string;
+}
+
+/**
+ * @internal
+ */
+export interface AssetImportmap {
+    /** true if asset should be written to importmap */
+    readonly importmap: boolean;
 }

--- a/src/assets/compile-options.ts
+++ b/src/assets/compile-options.ts
@@ -9,7 +9,7 @@ export interface CompileOptions {
      *
      * - `head` - the asset is injected in `<head>`
      * - `body` - the asset is injected in `<body>`
-     * - `none` (default) - the asset is not injected.
+     * - `none` (default) - the asset is not injected (but is available in importmap)
      */
     appendTo: "none" | "head" | "body";
 

--- a/src/assets/compile-script.spec.ts
+++ b/src/assets/compile-script.spec.ts
@@ -52,6 +52,7 @@ it("should compile and create asset in assets folder", async () => {
         name: "asset-name",
         src: "src/my-file.ts",
         buildOptions: {},
+        assets: [],
         vendor: [],
         fs: volume.promises as unknown as FSLike,
     });
@@ -63,20 +64,21 @@ it("should compile and create asset in assets folder", async () => {
     expect(volume.existsSync(expectedFilePath)).toBeTruthy();
 });
 
-it("should set all vendor libraries as external", async () => {
+it("should set assets and vendor libraries as external", async () => {
     expect.assertions(1);
     volume = Volume.fromJSON({});
     await compileScript({
         assetFolder: "public/assets",
         name: "asset-name",
         src: "src/my-file.ts",
+        assets: ["baz"],
         vendor: ["foo", { package: "bar" }],
         buildOptions: {},
         fs: volume.promises as unknown as FSLike,
     });
     expect(esbuild).toHaveBeenCalledWith(
         expect.objectContaining({
-            external: ["foo", "bar"],
+            external: ["baz", "foo", "bar"],
         }),
     );
 });
@@ -88,6 +90,7 @@ it("should set additional build options", async () => {
         assetFolder: "public/assets",
         name: "asset-name",
         src: "src/my-file.ts",
+        assets: [],
         vendor: [],
         buildOptions: {
             logLevel: "info",

--- a/src/assets/compile-script.spec.ts
+++ b/src/assets/compile-script.spec.ts
@@ -52,6 +52,7 @@ it("should compile and create asset in assets folder", async () => {
         name: "asset-name",
         src: "src/my-file.ts",
         buildOptions: {},
+        vendor: [],
         fs: volume.promises as unknown as FSLike,
     });
     const expectedFilename = `asset-name-${fingerprint}.js`;
@@ -62,6 +63,24 @@ it("should compile and create asset in assets folder", async () => {
     expect(volume.existsSync(expectedFilePath)).toBeTruthy();
 });
 
+it("should set all vendor libraries as external", async () => {
+    expect.assertions(1);
+    volume = Volume.fromJSON({});
+    await compileScript({
+        assetFolder: "public/assets",
+        name: "asset-name",
+        src: "src/my-file.ts",
+        vendor: ["foo", { package: "bar" }],
+        buildOptions: {},
+        fs: volume.promises as unknown as FSLike,
+    });
+    expect(esbuild).toHaveBeenCalledWith(
+        expect.objectContaining({
+            external: ["foo", "bar"],
+        }),
+    );
+});
+
 it("should set additional build options", async () => {
     expect.assertions(1);
     volume = Volume.fromJSON({});
@@ -69,6 +88,7 @@ it("should set additional build options", async () => {
         assetFolder: "public/assets",
         name: "asset-name",
         src: "src/my-file.ts",
+        vendor: [],
         buildOptions: {
             logLevel: "info",
             define: {

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { type BuildOptions } from "esbuild";
 import { getFingerprint, getIntegrity } from "../utils";
+import { VendorDefinition } from "../vendor";
 import { AssetInfo } from "./asset-info";
 import { esbuild } from "./esbuild-wrapper";
 
@@ -23,8 +24,13 @@ export interface CompileScriptOptions {
     assetFolder: string;
     name: string;
     src: string | URL;
+    vendor: VendorDefinition[];
     buildOptions: BuildOptions;
     fs?: FSLike;
+}
+
+function toExternal(vendor: VendorDefinition): string {
+    return typeof vendor === "string" ? vendor : vendor.package;
 }
 
 /**
@@ -37,6 +43,7 @@ export async function compileScript(
         assetFolder,
         name,
         src,
+        vendor,
         buildOptions,
         fs = nodeFS as FSLike,
     } = options;
@@ -52,7 +59,7 @@ export async function compileScript(
             bundle: true,
             format: "esm",
             platform: "browser",
-            external: ["vue", "@fkui/vue"],
+            external: vendor.map(toExternal),
             tsconfig: path.join(__dirname, "../tsconfig-examples.json"),
             ...buildOptions,
             define: {

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -24,12 +24,13 @@ export interface CompileScriptOptions {
     assetFolder: string;
     name: string;
     src: string | URL;
+    assets: string[];
     vendor: VendorDefinition[];
     buildOptions: BuildOptions;
     fs?: FSLike;
 }
 
-function toExternal(vendor: VendorDefinition): string {
+function toExternalVendor(vendor: VendorDefinition): string {
     return typeof vendor === "string" ? vendor : vendor.package;
 }
 
@@ -43,6 +44,7 @@ export async function compileScript(
         assetFolder,
         name,
         src,
+        assets,
         vendor,
         buildOptions,
         fs = nodeFS as FSLike,
@@ -53,13 +55,14 @@ export async function compileScript(
     try {
         const entryPoints = [src instanceof URL ? fileURLToPath(src) : src];
         const outfile = path.join("temp", `asset-${name}.js`);
+        const external = [...assets, ...vendor.map(toExternalVendor)];
         await esbuild({
             entryPoints,
             outfile,
             bundle: true,
             format: "esm",
             platform: "browser",
-            external: vendor.map(toExternal),
+            external,
             tsconfig: path.join(__dirname, "../tsconfig-examples.json"),
             ...buildOptions,
             define: {

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -50,7 +50,7 @@ export async function compileScript(
             entryPoints,
             outfile,
             bundle: true,
-            format: "iife",
+            format: "esm",
             platform: "browser",
             external: ["vue", "@fkui/vue"],
             tsconfig: path.join(__dirname, "../tsconfig-examples.json"),

--- a/src/assets/css-asset-processor.ts
+++ b/src/assets/css-asset-processor.ts
@@ -51,7 +51,10 @@ export function cssAssetProcessor(
                 );
                 const attrs = serializeAttrs(asset.options.attributes);
                 const inject = { ...info, attrs: Array.from(attrs).join(" ") };
-                assetInfo[asset.name] = info;
+                assetInfo[asset.name] = {
+                    ...info,
+                    importmap: false,
+                };
                 switch (asset.options.appendTo) {
                     case "none":
                         break;

--- a/src/assets/css-asset-processor.ts
+++ b/src/assets/css-asset-processor.ts
@@ -39,9 +39,9 @@ export function cssAssetProcessor(
         name: "css-asset-processor",
         after: "assets",
         async handler(context) {
-            const assetInfo = context.getTemplateData("assets") ?? {};
-            const head = context.getTemplateData("injectHead") ?? [];
-            const body = context.getTemplateData("injectBody") ?? [];
+            const assetInfo = context.getTemplateData("assets", {});
+            const head = context.getTemplateData("injectHead", []);
+            const body = context.getTemplateData("injectBody", []);
             for (const asset of toSorted(assets, byPriority)) {
                 const info = await compileStyle(
                     assetFolder,
@@ -62,11 +62,8 @@ export function cssAssetProcessor(
                         body.push(inject);
                         break;
                 }
-                context.setTemplateData("injectHead", head);
-                context.setTemplateData("injectBody", body);
                 context.log(info.filename, formatSize(info.size));
             }
-            context.setTemplateData("assets", assetInfo);
         },
     };
 }

--- a/src/assets/js-asset-processor.ts
+++ b/src/assets/js-asset-processor.ts
@@ -38,9 +38,9 @@ export function jsAssetProcessor(
         name: "js-asset-processor",
         after: "assets",
         async handler(context) {
-            const assetInfo = context.getTemplateData("assets") ?? {};
-            const head = context.getTemplateData("injectHead") ?? [];
-            const body = context.getTemplateData("injectBody") ?? [];
+            const assetInfo = context.getTemplateData("assets", {});
+            const head = context.getTemplateData("injectHead", []);
+            const body = context.getTemplateData("injectBody", []);
             for (const asset of toSorted(assets, byPriority)) {
                 const info = await compileScript({
                     assetFolder,
@@ -62,8 +62,6 @@ export function jsAssetProcessor(
                         body.push(inject);
                         break;
                 }
-                context.setTemplateData("injectHead", head);
-                context.setTemplateData("injectBody", body);
                 context.log(info.filename, formatSize(info.size));
             }
         },

--- a/src/assets/js-asset-processor.ts
+++ b/src/assets/js-asset-processor.ts
@@ -1,6 +1,7 @@
 import { type BuildOptions } from "esbuild";
 import { type Processor } from "../processor";
 import { formatSize, serializeAttrs } from "../utils";
+import { VendorDefinition } from "../vendor";
 import { type CompileOptions } from "./compile-options";
 import { compileScript } from "./compile-script";
 
@@ -31,6 +32,7 @@ function toSorted<T>(values: T[], comparator: (a: T, b: T) => number): T[] {
 export function jsAssetProcessor(
     assetFolder: string,
     assets: JSAsset[],
+    vendor: VendorDefinition[],
 ): Processor {
     return {
         name: "js-asset-processor",
@@ -44,6 +46,7 @@ export function jsAssetProcessor(
                     assetFolder,
                     name: asset.name,
                     src: asset.src,
+                    vendor,
                     buildOptions: asset.buildOptions,
                 });
                 const attrs = serializeAttrs(asset.options.attributes);

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -26,6 +26,7 @@ import { type Processor } from "./processor";
 import {
     type ProcessorContext,
     type TemplateBlockData,
+    type TemplateData,
 } from "./processor-context";
 import { type ProcessorStage } from "./processor-stage";
 import { redirectProcessor } from "./processors";
@@ -263,7 +264,8 @@ function createContext(
         },
 
         getAllTemplateData() {
-            return Object.fromEntries(templateData.entries());
+            return Object.fromEntries(templateData.entries()) as TemplateData &
+                Record<string, unknown>;
         },
 
         getTemplateData(key: string, defaultValue?: unknown): unknown {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -418,7 +418,7 @@ export class Generator {
             redirectProcessor(),
             vendorProcessor(assetFolder, this.vendor),
             cssAssetProcessor(assetFolder, this.styles, { cwd }),
-            jsAssetProcessor(assetFolder, this.scripts),
+            jsAssetProcessor(assetFolder, this.scripts, this.vendor),
             staticResourcesProcessor(assetFolder, this.resources),
             navigationProcessor(),
             nunjucksProcessor({

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -197,7 +197,7 @@ function createContext(
         children: [],
         visible: true,
     };
-    const templateData: Record<string, unknown> = {};
+    const templateData = new Map<string, unknown>();
     return {
         get docs(): Document[] {
             return docs;
@@ -263,15 +263,22 @@ function createContext(
         },
 
         getAllTemplateData() {
-            return templateData;
+            return Object.fromEntries(templateData.entries());
         },
 
-        getTemplateData(key: string): unknown {
-            return templateData[key];
+        getTemplateData(key: string, defaultValue?: unknown): unknown {
+            if (templateData.has(key)) {
+                return templateData.get(key);
+            } else if (defaultValue) {
+                templateData.set(key, defaultValue);
+                return defaultValue;
+            } else {
+                return undefined;
+            }
         },
 
         setTemplateData(key: string, value: unknown) {
-            templateData[key] = value;
+            templateData.set(key, value);
         },
     };
 }

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -363,6 +363,29 @@ exports[`smoketest 1`] = `
       "children": [
         {
           "external": false,
+          "id": "fs:docs/configuration/index.md",
+          "path": "./configuration/",
+          "sortorder": Infinity,
+          "title": "Configuration",
+        },
+        {
+          "external": false,
+          "id": "fs:docs/configuration/scripts.md",
+          "path": "./configuration/scripts.html",
+          "sortorder": Infinity,
+          "title": "Scripts",
+        },
+      ],
+      "key": "./configuration",
+      "path": "./configuration/",
+      "sortorder": Infinity,
+      "title": "Configuration",
+      "visible": true,
+    },
+    {
+      "children": [
+        {
+          "external": false,
           "id": "fs:docs/live-example/example.md",
           "path": "./live-example/example.html",
           "sortorder": Infinity,

--- a/src/processor-context.ts
+++ b/src/processor-context.ts
@@ -83,7 +83,7 @@ export interface ProcessorContext {
     setTopNavigation(root: NavigationSection): void;
     setSideNavigation(root: NavigationSection): void;
 
-    getAllTemplateData(): Record<string, unknown>;
+    getAllTemplateData(): TemplateData & Record<string, unknown>;
 
     getTemplateData<K extends keyof TemplateData>(
         key: K,

--- a/src/processor-context.ts
+++ b/src/processor-context.ts
@@ -88,6 +88,10 @@ export interface ProcessorContext {
     getTemplateData<K extends keyof TemplateData>(
         key: K,
     ): TemplateData[K] | undefined;
+    getTemplateData<K extends keyof TemplateData>(
+        key: K,
+        defaultValue: TemplateData[K],
+    ): TemplateData[K];
     getTemplateData(key: string): unknown;
 
     setTemplateData<K extends keyof TemplateData>(

--- a/src/render/render-options.ts
+++ b/src/render/render-options.ts
@@ -1,4 +1,7 @@
-import { type TemplateBlockData } from "../processor-context";
+import {
+    type TemplateBlockData,
+    type TemplateData,
+} from "../processor-context";
 
 /**
  * @internal
@@ -14,7 +17,7 @@ export interface RenderOptions {
     templateFolders: string[];
     setupPath: string;
     templateBlocks: Map<string, Array<TemplateBlockData<unknown>>>;
-    templateData: Record<string, unknown>;
+    templateData: TemplateData & Record<string, unknown>;
 
     markdown: {
         messagebox?: {

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -237,16 +237,25 @@ export async function render(
         sidenav,
         vendors,
         importmap(doc: DocumentPage): string {
-            const imports = Object.fromEntries(
-                vendors.map((it) => {
+            const assets = Object.values(templateData.assets).filter(
+                (it) => it.importmap,
+            );
+            const imports = Object.fromEntries([
+                ...vendors.map((it) => {
                     return [it.package, filter.relative(it.publicPath, doc)];
                 }),
-            );
-            const integrity = Object.fromEntries(
-                vendors.map((it) => {
+                ...assets.map((it) => {
+                    return [it.name, filter.relative(it.publicPath, doc)];
+                }),
+            ]);
+            const integrity = Object.fromEntries([
+                ...vendors.map((it) => {
                     return [filter.relative(it.publicPath, doc), it.integrity];
                 }),
-            );
+                ...assets.map((it) => {
+                    return [filter.relative(it.publicPath, doc), it.integrity];
+                }),
+            ]);
             const importmap = { imports, integrity };
             return JSON.stringify(importmap, null, 2);
         },

--- a/templates/base.template.html
+++ b/templates/base.template.html
@@ -27,6 +27,7 @@
         {%- for asset in injectHead | take("type", "js") %}
         <script
             src="{{ asset.publicPath | relative(doc) }}"
+            type="module"
             crossorigin
             integrity="{{ asset.integrity }}"
             {{
@@ -122,6 +123,7 @@
         {%- for asset in injectBody | take("type", "js") %}
         <script
             src="{{ asset.publicPath | relative(doc) }}"
+            type="module"
             crossorigin
             integrity="{{ asset.integrity }}"
             {{


### PR DESCRIPTION
Ska skriva lite dokumentation för det här innan merge men man kan börja granska koden.

Det är två relaterade saker vi löser här:

1. Idag om man importerar `@fkui/vue` från ett script som kompileras med `compileScript()` så byggs det som CJS med `require()` vilket då inte längre lirar så vendors nu är ESM. Det har vi inte själva märkt då vi inte importerar `@fkui/vue` där.
2. Vi har problem att `setup()` kan anropas före alla script körts klart, det märks tydligare nu efter punkt 1 är löst så alla `<script type="module">` alltid implicit är `defer` och då körs de i fel ordning.

Dels så rättar denna så allt byggs som ESM men den lägger också till stöd för att lägga till egna scripts i importmap, det löser så man från `setup()` kan importera och vänta på andra script (med eller utan side-effects).

Konkret exempel:

`docs/src/get-translation-provider.ts`:

```ts
export function getTranslationProvider() {
  return /* ... */
}
```

`docs/src/setup.ts`:

```ts
/* importen kommer vänta ut att scriptet hämtats */
import { getTranslationProvider } from "translations";

export function setup() {
  /* om funktionen är async kan vi awaita resultatet */
  const provider = await getTranslationProvider();
}
```

`generate-docs.mjs`:

```ts
/* namnet "translation" är det som landar i importmap och det man importerar från senare */
compileScript("translations", "./docs/src/get-translation-provider.ts", {
    attachTo: "none",
});
```