### PR TITLE
feat: support search.terms to provide additional search terms

### DIFF
--- a/docs/processors/search.md
+++ b/docs/processors/search.md
@@ -1,0 +1,51 @@
+---
+name: Search processor
+layout: article
+search:
+    terms:
+        - searchProcessor
+---
+
+The `searchProcessor` adds a search function to the generated site and creates a searchable index.
+
+The index is based on:
+
+- the page title
+- the component name(s)
+- additional extra search terms given in the document.
+
+## Usage
+
+```ts
+import { Generator, searchProcessor } from "@forsakringskassan/docs-generator";
+
+/* --- cut above --- */
+
+const docs = new Generator({
+    /* --- cut begin --- */
+    site: { name: ".." },
+    setupPath: "..",
+    /* --- cut end --- */
+
+    processors: [searchProcessor()],
+});
+```
+
+## Configuration
+
+This processor has no configuration.
+
+## Search terms
+
+The the markdown document a list of additional search terms can be listed in the frontmatter block:
+
+```md
+---
+search:
+    terms:
+        - foo
+        - bar
+---
+```
+
+Searching for any of those terms will show results for the page.

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -48,6 +48,7 @@ processors/index.html
 processors/manifest.html
 processors/motd.html
 processors/nunjucks.html
+processors/search.html
 processors/source-url.html
 processors/topnav.html
 processors/version.html

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -261,6 +261,9 @@ export interface NormalizedDocumentAttributes {
     layout?: string;
     // (undocumented)
     redirectFrom: string[];
+    search: {
+        terms: string[];
+    };
     // (undocumented)
     shortTitle?: string;
     sortorder: number;

--- a/etc/markdown.api.md
+++ b/etc/markdown.api.md
@@ -141,6 +141,9 @@ export interface NormalizedDocumentAttributes {
     layout?: string;
     // (undocumented)
     redirectFrom: string[];
+    search: {
+        terms: string[];
+    };
     // (undocumented)
     shortTitle?: string;
     sortorder: number;

--- a/src/document/document-attributes.ts
+++ b/src/document/document-attributes.ts
@@ -50,6 +50,12 @@ export interface DocumentAttributes {
     /** link to external page in navigation */
     href?: string;
 
+    /** Search options */
+    search?: {
+        /* Optional list of additional search terms for this page */
+        terms?: string | string[];
+    };
+
     /** navigation sortorder */
     sortorder?: number;
 
@@ -68,6 +74,11 @@ export interface NormalizedDocumentAttributes {
     badge?: DocumentBadge;
     component?: ComponentAttribute[];
     href?: string;
+    /** search options */
+    search: {
+        /** list of additional search terms for this page */
+        terms: string[];
+    };
     /** normalized sortorder (defaults to Infinity) */
     sortorder: number;
     redirectFrom: string[];
@@ -87,6 +98,7 @@ export const documentAttributeKeys = [
     "include",
     "component",
     "href",
+    "search",
     "sortorder",
     "redirect_from",
 ];

--- a/src/file-reader/front-matter-file-reader.ts
+++ b/src/file-reader/front-matter-file-reader.ts
@@ -150,6 +150,9 @@ export function parseFile(
             badge: getBadge(attributes),
             component: getComponent(attributes),
             redirectFrom: toArray(attributes.redirect_from ?? []),
+            search: {
+                terms: toArray(attributes.search?.terms ?? []),
+            },
             sortorder: attributes.sortorder ?? Infinity,
         },
         body: blocks.body,

--- a/src/file-reader/navigation-file-reader.ts
+++ b/src/file-reader/navigation-file-reader.ts
@@ -36,6 +36,7 @@ export function parseFile(
             href,
             sortorder: attributes.sortorder ?? Infinity,
             redirectFrom: [],
+            search: { terms: [] },
         },
         body: content,
         outline: [],

--- a/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
+++ b/src/navigation/__snapshots__/generate-navtree.spec.ts.snap
@@ -317,6 +317,13 @@ exports[`smoketest 1`] = `
         },
         {
           "external": false,
+          "id": "fs:docs/processors/search.md",
+          "path": "./processors/search.html",
+          "sortorder": Infinity,
+          "title": "Search processor",
+        },
+        {
+          "external": false,
           "id": "fs:docs/processors/source-url.md",
           "path": "./processors/source-url.html",
           "sortorder": Infinity,

--- a/src/navigation/generate-navtree.spec.ts
+++ b/src/navigation/generate-navtree.spec.ts
@@ -33,6 +33,7 @@ function createDocument(
             title,
             sortorder: Infinity /* sorting is tested separately */,
             redirectFrom: [],
+            search: { terms: [] },
             ...doc?.attributes,
         },
     };
@@ -65,7 +66,11 @@ it("should merge root index.md to root node", () => {
 it("should store sort order from document", () => {
     const nav = generateNavtree([
         createDocument("index.md", "Frontpage", {
-            attributes: { sortorder: 10, redirectFrom: [] },
+            attributes: {
+                sortorder: 10,
+                redirectFrom: [],
+                search: { terms: [] },
+            },
         }),
     ]);
     expect(nav).toEqual(
@@ -83,6 +88,7 @@ it("should use short title if present", () => {
                 shortTitle: "Short",
                 sortorder: Infinity,
                 redirectFrom: [],
+                search: { terms: [] },
             },
         }),
     ]);
@@ -162,7 +168,11 @@ it("should create children for each folder", () => {
         createDocument("usage/index.md", "Usage guide"),
         createDocument("usage/foo.md", "Foo component"),
         createDocument("components/index.md", "Components", {
-            attributes: { sortorder: 10, redirectFrom: [] },
+            attributes: {
+                sortorder: 10,
+                redirectFrom: [],
+                search: { terms: [] },
+            },
         }),
     ]);
     expect(nav).toEqual({
@@ -220,10 +230,18 @@ it("should create children for each folder (inverse order)", () => {
         createDocument("components/index.md", "Components"),
         createDocument("usage/foo.md", "Foo component"),
         createDocument("usage/index.md", "Usage guide", {
-            attributes: { sortorder: 20, redirectFrom: [] },
+            attributes: {
+                sortorder: 20,
+                redirectFrom: [],
+                search: { terms: [] },
+            },
         }),
         createDocument("index.md", "Frontpage", {
-            attributes: { sortorder: 10, redirectFrom: [] },
+            attributes: {
+                sortorder: 10,
+                redirectFrom: [],
+                search: { terms: [] },
+            },
         }),
     ]);
     expect(nav).toEqual({
@@ -394,7 +412,11 @@ it("should read title and sortorder from hidden index.md", () => {
     const nav = generateNavtree([
         createDocument("usage/index.md", "Usage guide", {
             visible: false,
-            attributes: { sortorder: 10, redirectFrom: [] },
+            attributes: {
+                sortorder: 10,
+                redirectFrom: [],
+                search: { terms: [] },
+            },
         }),
         createDocument("usage/foo.md", "Foo component"),
     ]);

--- a/src/processors/redirect/redirect-processor.ts
+++ b/src/processors/redirect/redirect-processor.ts
@@ -24,6 +24,7 @@ export function redirectProcessor(): Processor {
                     attributes: {
                         sortorder: Infinity,
                         redirectFrom: [],
+                        search: { terms: [] },
                     },
                     body: redirect.to,
                     outline: [],

--- a/src/render/inline-tags/link.spec.ts
+++ b/src/render/inline-tags/link.spec.ts
@@ -22,6 +22,7 @@ const docs = [
             title: "Document with title",
             sortorder: Infinity,
             redirectFrom: [],
+            search: { terms: [] },
         },
     }),
     createMockDocument("with-name", "./components/with-name.html"),
@@ -31,6 +32,7 @@ const docs = [
             component: [{ name: "FFirst" }, { name: "FSecond" }],
             sortorder: Infinity,
             redirectFrom: [],
+            search: { terms: [] },
         },
     }),
 ];

--- a/src/runtime/search.ts
+++ b/src/runtime/search.ts
@@ -49,13 +49,17 @@ function setup(): void {
             const infoIdx = order[i];
             const termIdx = info.idx[infoIdx];
             const resultIdx = index.mapping[termIdx];
+            const term = index.terms[termIdx];
+            const result = index.results[resultIdx];
             const li = document.createElement("li");
             const a = document.createElement("a");
-            a.innerHTML = uFuzzy.highlight(
-                index.terms[termIdx],
-                info.ranges[infoIdx],
-            );
-            a.href = [rootUrl, index.results[resultIdx].url].join("/");
+            const highlighted = uFuzzy.highlight(term, info.ranges[infoIdx]);
+            if (result.terms.includes(term)) {
+                a.innerHTML = `${result.title} (${highlighted})`;
+            } else {
+                a.innerHTML = highlighted;
+            }
+            a.href = [rootUrl, result.url].join("/");
             a.classList.add("list__item__itempane");
             li.classList.add("list__item");
             li.classList.toggle("list__item--active", i === active);

--- a/src/search/generate-index.spec.ts
+++ b/src/search/generate-index.spec.ts
@@ -2,9 +2,9 @@ import { generateIndex } from "./generate-index";
 import { type SearchEntry } from "./search-entry";
 
 const entries: SearchEntry[] = [
-    { url: "a.html", title: "A", words: ["Foo", "Bar"] },
-    { url: "b.html", title: "B", words: ["Baz"] },
-    { url: "c.html", title: "C", words: ["Spam", "Ham"] },
+    { url: "a.html", title: "A", terms: ["Bar"], words: ["Foo", "Bar"] },
+    { url: "b.html", title: "B", terms: [], words: ["Baz"] },
+    { url: "c.html", title: "C", terms: [], words: ["Spam", "Ham"] },
 ];
 
 it("should generate list of all terms", () => {
@@ -17,9 +17,9 @@ it("should generate list of all results", () => {
     expect.assertions(1);
     const index = generateIndex(entries);
     expect(index.results).toEqual([
-        { url: "a.html", title: "A" },
-        { url: "b.html", title: "B" },
-        { url: "c.html", title: "C" },
+        { url: "a.html", title: "A", terms: ["Bar"] },
+        { url: "b.html", title: "B", terms: [] },
+        { url: "c.html", title: "C", terms: [] },
     ]);
 });
 

--- a/src/search/generate-index.ts
+++ b/src/search/generate-index.ts
@@ -14,6 +14,7 @@ export function generateIndex(entries: SearchEntry[]): SearchIndex {
         index.results.push({
             url: entry.url,
             title: entry.title,
+            terms: entry.terms,
         });
         const resultIndex = index.results.length - 1;
         for (const word of entry.words) {

--- a/src/search/search-entry.ts
+++ b/src/search/search-entry.ts
@@ -1,5 +1,9 @@
+/**
+ * @internal
+ */
 export interface SearchEntry {
     url: string;
     title: string;
+    terms: string[];
     words: string[];
 }

--- a/src/search/search-index.ts
+++ b/src/search/search-index.ts
@@ -2,7 +2,7 @@ export interface SearchIndex {
     /* list of all possible search terms */
     terms: string[];
     /* list of all possible search results */
-    results: Array<{ url: string; title: string }>;
+    results: Array<{ url: string; title: string; terms: string[] }>;
     /* mapping between terms and resutls (index -> index) */
     mapping: Record<number, number>;
 }

--- a/src/utils/create-mock-document.ts
+++ b/src/utils/create-mock-document.ts
@@ -21,6 +21,9 @@ export function createMockDocument(
         attributes: {
             sortorder: Infinity,
             redirectFrom: [],
+            search: {
+                terms: [],
+            },
             ...doc?.attributes,
         },
         body: "",


### PR DESCRIPTION
Bryter ut från #196 

---

Stöd för att lägga till extra söktermer på sidor:

Som exempel:

```diff
 title: Tabell
 status: Produktionsklar
 layout: component
 sortorder: 1
+search:
+    terms:
+        - Table
component:
    - FDataTable
    - FInteractiveTable
    - FTableColumn
```

Då plockar sökindex upp att "table" också ska leda till denna sidan.

Framtida förbättring: dölj dubletter från sökresultat, exempelvis "tab" matchar både "Tabell" (sidnamnet) och "table" (term), då behöver vi inte visa båda.

---

Har lagt in lite rudimentär dokumentation över hur det fungerar.
