### PR TITLE
fix: ignore whitespace in generated diffs

### DIFF
--- a/src/render/markdown/code-preview.ts
+++ b/src/render/markdown/code-preview.ts
@@ -57,6 +57,7 @@ function getSource(
         const b = transformCode(content, language);
         const diff = createTwoFilesPatch("a", "b", a, b, "", "", {
             context: context ? parseInt(context, 10) : 3,
+            ignoreWhitespace: true,
         })
             .split("\n")
             .slice(4) // remove header


### PR DESCRIPTION
Given markdown input:

````md
```html name=base
<p>lorem ipsum</p>
```

```html compare=base
<div>
  <p>lorem ipsum</p>
</div>
```
````

The following is rendered:

**Before:**

```diff
-<p>lorem ipsum</p>
+<div>
+  <p>lorem ipsum</p>
+</div>
```

**After:**

```diff
+<div>
  <p>lorem ipsum</p>
+</div>
```
