### PR TITLE
fix: find doccomment attached to variable from `$t()`

### DIFF
--- a/src/file-reader/vue-file-reader/find-translations.spec.ts
+++ b/src/file-reader/vue-file-reader/find-translations.spec.ts
@@ -390,3 +390,30 @@ it("should find description", () => {
         },
     ]);
 });
+
+it("should find description from variable declaration", () => {
+    expect.assertions(1);
+    const content = dedent(/* HTML */ `
+        <script setup>
+            import { useTranslate } from "@fkui/vue";
+
+            const $t = useTranslate();
+
+            /** lorem ipsum */
+            const text = $t("my.awesome.key");
+        </script>
+
+        <template>
+            <pre>{{ text }}</pre>
+        </template>
+    `);
+    const result = findTranslations("AwesomeComponent.vue", content);
+    expect(result).toEqual([
+        {
+            name: "my.awesome.key",
+            defaultTranslation: null,
+            description: "lorem ipsum",
+            parameters: [],
+        },
+    ]);
+});

--- a/src/file-reader/vue-file-reader/find-translations.ts
+++ b/src/file-reader/vue-file-reader/find-translations.ts
@@ -142,6 +142,19 @@ function findDocComment(
         }
     }
 
+    /* find comment from variable declaration */
+    const grandparent = path.parentPath?.parent;
+    if (
+        parent.type === "VariableDeclarator" &&
+        grandparent &&
+        grandparent.leadingComments
+    ) {
+        const doc = grandparent.leadingComments.find(isDocComment);
+        if (doc) {
+            return doc;
+        }
+    }
+
     return null;
 }
 


### PR DESCRIPTION
fixes #205