### PR TITLE
feat: support translation with i18next

### DIFF
--- a/generate-docs.mjs
+++ b/generate-docs.mjs
@@ -22,7 +22,7 @@ const pkg = JSON.parse(await fs.readFile("./package.json", "utf-8"));
 const docs = new Generator({
     site: {
         name: "FK Documentation generator",
-        lang: "sv",
+        lang: "en",
     },
     outputFolder: "./public",
     cacheFolder: "./temp/docs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "fs-extra": "11.3.0",
         "glob": "11.0.1",
         "highlight.js": "11.11.1",
+        "i18next": "24.2.3",
         "livereload-js": "4.0.2",
         "markdown-it": "14.1.0",
         "markdown-it-deflist": "3.0.0",
@@ -651,6 +652,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -10128,6 +10141,37 @@
         "node": ">=10.18"
       }
     },
+    "node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -14743,6 +14787,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "fs-extra": "11.3.0",
     "glob": "11.0.1",
     "highlight.js": "11.11.1",
+    "i18next": "24.2.3",
     "livereload-js": "4.0.2",
     "markdown-it": "14.1.0",
     "markdown-it-deflist": "3.0.0",

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import fse from "fs-extra";
+import { createInstance as i18next } from "i18next";
 import {
     type CompileOptions,
     type CSSAsset,
@@ -15,6 +16,8 @@ import { compileProcessorRuntime } from "./compile-processor-runtime";
 import { type SourceFiles, fileReaderProcessor } from "./file-reader";
 import { nunjucksProcessor, TemplateLoader } from "./render";
 import { isDocumentPage, type Document } from "./document";
+import langEn from "./i18n/en.json";
+import langSv from "./i18n/sv.json";
 import { manifestPageFromDocument } from "./manifest";
 import { type NavigationSection, navigationProcessor } from "./navigation";
 import {
@@ -428,6 +431,17 @@ export class Generator {
             markdownOptions,
         } = this;
 
+        const i18n = i18next({
+            lng: site.lang,
+            fallbackLng: "en",
+            resources: {
+                en: langEn,
+                sv: langSv,
+            },
+        });
+
+        await i18n.init();
+
         await this._prepareFolders();
 
         const processors: Processor[] = [
@@ -445,6 +459,7 @@ export class Generator {
                 },
                 outputFolder,
                 cacheFolder,
+                i18n,
                 exampleFolders,
                 templateFolders,
                 setupPath,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,17 @@
+{
+    "translation": {
+        "component": {
+            "component": "Component",
+            "status": "Status"
+        },
+        "outline": {
+            "in-this-article": "In this article"
+        },
+        "search": {
+            "button": "Search",
+            "instructions": "<kbd>Esc</kbd> to close <kbd>Arrow up/down</kbd> to navigate <kbd>Enter</kbd> to select",
+            "title": "Search",
+            "placeholder": "Type to begin searching"
+        }
+    }
+}

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1,0 +1,17 @@
+{
+    "translation": {
+        "component": {
+            "component": "Komponent",
+            "status": "Status"
+        },
+        "outline": {
+            "in-this-article": "Innehåll"
+        },
+        "search": {
+            "button": "Sök",
+            "instructions": "<kbd>Esc</kbd> för att stänga <kbd>Pil upp/ner</kbd> för att navigera <kbd>Enter</kbd> för att välja",
+            "title": "Sök",
+            "placeholder": "Skriv för att börja söka"
+        }
+    }
+}

--- a/src/render/render-options.ts
+++ b/src/render/render-options.ts
@@ -1,3 +1,4 @@
+import { type i18n } from "i18next";
 import {
     type TemplateBlockData,
     type TemplateData,
@@ -14,6 +15,7 @@ export interface RenderOptions {
     outputFolder: string;
     cacheFolder: string;
     exampleFolders: string[];
+    i18n: i18n;
     templateFolders: string[];
     setupPath: string;
     templateBlocks: Map<string, Array<TemplateBlockData<unknown>>>;

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -213,7 +213,7 @@ export async function render(
     options: RenderOptions,
 ): Promise<string | null> {
     const { fileInfo } = doc;
-    const { outputFolder, cacheFolder, templateFolders } = options;
+    const { i18n, outputFolder, cacheFolder, templateFolders } = options;
 
     /* skip rendering files which have no output */
     if (!haveOutputFile(fileInfo)) {
@@ -236,6 +236,7 @@ export async function render(
     const template = findTemplate(templateFolders, doc.fileInfo, doc);
     const templateData = {
         ...options.templateData,
+        $t: i18n.t,
         site: options.site,
         doc,
         get layoutClass() {

--- a/templates/base.template.html
+++ b/templates/base.template.html
@@ -89,7 +89,7 @@
 
                         {% if doc.outline | length %}
                         <details id="outline">
-                            <summary class="outline__heading">Innehåll</summary>
+                            <summary class="outline__heading">{{ $t('outline.in-this-article') }}</summary>
                             <ul>
                                 {% for heading in doc.outline %}
                                 <li><a href="#{{ heading.anchor }}">{{ heading.title | escape }}</a></li>

--- a/templates/component.template.html
+++ b/templates/component.template.html
@@ -4,7 +4,7 @@
 {% block aside %}
 <dl>
     {% if doc.attributes.component %}
-    <dt>Komponent</dt>
+    <dt>{{ $t('component.component') }}</dt>
     <dd>
         <div class="docs-badge-list">
             {% for component in doc.attributes.component %}
@@ -23,7 +23,7 @@
     {% endif %}
 
     {% if doc.attributes.status %}
-    <dt>Status</dt>
+    <dt>{{ $t('component.status') }}</dt>
     <dd>
         <div class="badge badge--{{ doc.attributes.badge }}">{{ doc.attributes.status }}</div>
     </dd>

--- a/templates/partials/search-dialog.html
+++ b/templates/partials/search-dialog.html
@@ -2,7 +2,7 @@
     <!-- [html-validate-disable-next wcag/h32 -- handled via script] -->
     <form id="search-form">
         <div class="text-field">
-            <label for="search-field" class="label"> Sök </label>
+            <label for="search-field" class="label">{{ $t('search.title') }}</label>
             <div class="text-field__input-wrapper">
                 <div class="text-field__icon-wrapper">
                     <input
@@ -14,12 +14,12 @@
                         type="text"
                         class="text-field__input"
                         maxlength="50"
-                        placeholder="Skriv för att börja söka"
+                        placeholder="{{ $t('search.placeholder') }}"
                     />
                 </div>
             </div>
         </div>
         <div id="search-results"></div>
-        <p><kbd>Esc</kbd> för att stänga <kbd>Pil upp/ner</kbd> för att navigera <kbd>Enter</kbd> för att välja</p>
+        <p>{{ $t('search.instructions') }}</p>
     </form>
 </dialog>

--- a/templates/partials/search-toolbar.html
+++ b/templates/partials/search-toolbar.html
@@ -3,7 +3,7 @@
         <button class="text-field__input" type="submit">
             <svg focusable="false" class="icon button__icon">
                 <use xlink:href="#docs-icon-search"></use></svg
-            >Sök <kbd>ctrl-k</kbd>
+            >{{ $t('search.button') }} <kbd>ctrl-k</kbd>
         </button>
     </form>
 </div>


### PR DESCRIPTION
Utbrutet från #196

---

Stöd för att översätta siten som är genererad med docs-generator. Idag är det en del hårdkodade texter så som "Innehåll", "Sök" osv, nu översätts texter baserat på vad man skickar in för `site.lang` inställning.

Det finns säkert texter som inte översätts än men stödet finns nu iaf.
