### PR TITLE
scrollbar fixes

### DIFF
--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -215,7 +215,7 @@ function getVisibleHeight(el: HTMLElement): number {
     } else {
         const top = Math.max(-rect.top, 0);
         const bottom = rect.height - Math.max(rect.bottom - clientHeight, 0);
-        return bottom - top;
+        return Math.floor(bottom - top);
     }
 }
 

--- a/src/style/_navigation.scss
+++ b/src/style/_navigation.scss
@@ -6,6 +6,7 @@
 
     overflow: auto;
     max-height: calc(100vh - var(--header-footer-visible-height));
+    scrollbar-gutter: stable;
     position: sticky;
     top: 0;
 }


### PR DESCRIPTION
Löser inte hela problemet, jag tror att vi måste göra om hela konceptet från scratch men får nog dubbelkolla med @johancarnegard och @niklasfk hur det ska fungera egentligen. Det finns flera olika scenarion att ha i beaktning:

* [Sida](https://designsystem.forsakringskassan.se/latest/components/) med lång meny, kort innehåll
* [Sida](https://designsystem.forsakringskassan.se/latest/styles/colors.html) med kort meny, långt innehåll
* [Sida](https://designsystem.forsakringskassan.se/latest/components/flabel.html) med lång meny, långt innehåll
* [Sida](https://designsystem.forsakringskassan.se/latest/guides/) med kort meny, kort innehåll
* Fönsterstorlek där meny inte får plats på höjden från början
* Fönsterstorlek där meny alltid får plats (aldrig scrollbar)

Footer beter sig väldigt udda nu på sidor (testa scrolla långtsamt ner på en sida med lång meny, kort innehåll). Menyn är dessutom inte sticky så som jag tror vi sa att den skulle vara, kanske fungerat en gång i tiden men den är då inte sticky nu.

Med det sagt, det här löser de värsta problemen framförallt när man fastnar i en loop där scrollbar stängs av/på och hela innehållet åker upp och ner. Iaf i de lägen där jag kan återskapa problemet.