### PR TITLE
fix: fix list items being rendered with paragraph tag

### DIFF
--- a/src/render/markdown/__snapshots__/paragraph.spec.ts.snap
+++ b/src/render/markdown/__snapshots__/paragraph.spec.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not add paragraph to list items 1`] = `
+"<ul>
+<li>foo</li>
+<li>bar</li>
+<li>baz</li>
+</ul>
+<p class="docs-paragraph">lorem ipsum</p>
+<ul>
+<li>spam</li>
+<li>ham</li>
+</ul>
+"
+`;
+
+exports[`should render paragraph with class 1`] = `
+"<p class="docs-paragraph">lorem ipsum
+dolor sit amet</p>
+<p class="docs-paragraph">foo bar baz
+spam ham</p>
+"
+`;

--- a/src/render/markdown/paragraph.spec.ts
+++ b/src/render/markdown/paragraph.spec.ts
@@ -1,0 +1,32 @@
+import markdownIt from "markdown-it";
+import { paragraph } from "./paragraph";
+
+const md = markdownIt();
+md.use(paragraph());
+
+it("should render paragraph with class", () => {
+    expect.assertions(1);
+    const markup = md.render(`
+lorem ipsum
+dolor sit amet
+
+foo bar baz
+spam ham
+`);
+    expect(markup).toMatchSnapshot();
+});
+
+it("should not add paragraph to list items", () => {
+    expect.assertions(1);
+    const markup = md.render(`
+- foo
+- bar
+- baz
+
+lorem ipsum
+
+* spam
+* ham
+`);
+    expect(markup).toMatchSnapshot();
+});

--- a/src/render/markdown/paragraph.ts
+++ b/src/render/markdown/paragraph.ts
@@ -1,10 +1,18 @@
 import type MarkdownIt from "markdown-it";
 
 export function paragraph(): (md: MarkdownIt) => void {
+    const renderToken: MarkdownIt.Renderer.RenderRule = (...args) => {
+        const [tokens, idx, options, , self] = args;
+        return self.renderToken(tokens, idx, options);
+    };
+
     return function (md: MarkdownIt): void {
         /* eslint-disable camelcase -- property is defined in upstream library */
-        md.renderer.rules.paragraph_open = () => `<p class="docs-paragraph">`;
-        md.renderer.rules.paragraph_close = () => `</p>`;
+        const renderRule = md.renderer.rules.paragraph_open ?? renderToken;
+        md.renderer.rules.paragraph_open = (tokens, idx, index, env, self) => {
+            tokens[idx].attrJoin("class", "docs-paragraph");
+            return renderRule(tokens, idx, index, env, self);
+        };
         /* eslint-enable camelcase */
     };
 }


### PR DESCRIPTION
Trodde ändringen i 0fe71ac skulle vara ganska harmlös men den har ju sönder listor (men ingen skriker?)

Reagerade på att listan i @MCFK's [PR ser konstig ut](https://forsakringskassan.github.io/designsystem/pr-preview/pr-421/functions/plugins/formatplugin.html).

Givet:

```md
* foo
* bar
* baz
```

Förväntad HTML:

```html
<ul>
<li>foo</li>
<li>bar</li>
<li>baz</li>
</ul>
```

Istället får man:

```html
<ul>
<li><p class="docs-paragraph">foo</p></li>
<li><p class="docs-paragraph">bar</p></li>
<li><p class="docs-paragraph">baz</p></li>
</ul>
```

Denna bugfixen korrigerar det, nu renderas bara "riktiga" stycken med `<p>`.