### PR TITLE
ci: change build to supported node versions (fixes SFKUI-0000)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [18.x, 20.x, 21.x]
+                node-version: [18.x, 20.x, 22.x]
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Removed node 21 since it´s no longer supporter. Soon 18 will be unsupported and 24 released(current).