### PR TITLE
feat: convert package to esm

### DIFF
--- a/api-extractor-index.json
+++ b/api-extractor-index.json
@@ -6,6 +6,6 @@
         "reportFileName": "index.api.md"
     },
     "dtsRollup": {
-        "publicTrimmedFilePath": "<projectFolder>/dist/index.d.ts"
+        "publicTrimmedFilePath": "<projectFolder>/dist/index.d.mts"
     }
 }

--- a/api-extractor-markdown.json
+++ b/api-extractor-markdown.json
@@ -6,6 +6,6 @@
         "reportFileName": "markdown.api.md"
     },
     "dtsRollup": {
-        "publicTrimmedFilePath": "<projectFolder>/dist/markdown.d.ts"
+        "publicTrimmedFilePath": "<projectFolder>/dist/markdown.d.mts"
     }
 }

--- a/api-extractor-runtime.json
+++ b/api-extractor-runtime.json
@@ -6,6 +6,6 @@
         "reportFileName": "runtime.api.md"
     },
     "dtsRollup": {
-        "publicTrimmedFilePath": "<projectFolder>/dist/runtime.d.ts"
+        "publicTrimmedFilePath": "<projectFolder>/dist/runtime.d.mts"
     }
 }

--- a/docs.config.mjs
+++ b/docs.config.mjs
@@ -2,7 +2,7 @@ import {
     frontMatterFileReader,
     navigationFileReader,
     vueFileReader,
-} from "./dist/index.js";
+} from "./dist/index.mjs";
 
 /**
  * @param {string} name - Prefixed name of css variable.

--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -1,1 +1,2 @@
-import "../../dist/runtime";
+/* eslint-disable-next-line import/extensions -- needed for import to resolve */
+import "../../dist/runtime.mjs";

--- a/generate-docs.mjs
+++ b/generate-docs.mjs
@@ -13,7 +13,7 @@ import {
     sourceUrlProcessor,
     cookieProcessor,
     selectableVersionProcessor,
-} from "./dist/index.js";
+} from "./dist/index.mjs";
 import config from "./docs.config.mjs";
 
 const isRelease = Boolean(process.env.RELEASE);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,18 @@
+import * as path from "node:path";
+
+/* workarounds for jest not supporting `import.meta.*` so we manually mock these
+ * exports using commonjs instead */
+
+jest.mock("./src/render/template-directory", () => {
+    return {
+        __esModule: true,
+        templateDirectory: path.join(__dirname, "templates"),
+    };
+});
+
+jest.mock("./src/tsconfig-path", () => {
+    return {
+        __esModule: true,
+        tsconfigPath: path.join(__dirname, "tsconfig-examples.json"),
+    };
+});

--- a/package.json
+++ b/package.json
@@ -14,21 +14,32 @@
   "license": "MIT",
   "author": "Försäkringskassan",
   "sideEffects": [
-    "dist/runtime-bootstrap.js",
-    "dist/runtime.js",
+    "dist/runtime-bootstrap.mjs",
+    "dist/runtime.mjs",
     "src/runtime/**/*"
   ],
+  "type": "module",
   "exports": {
-    ".": "./dist/index.js",
-    "./markdown": "./dist/markdown.js",
-    "./runtime": "./dist/runtime.js",
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./markdown": {
+      "types": "./dist/markdown.d.mts",
+      "default": "./dist/markdown.mjs"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.mts",
+      "default": "./dist/runtime.mjs"
+    },
     "./docs": "./dist/style/index.css",
     "./docs.css": "./dist/style/index.css",
     "./style": "./dist/style/index.css",
     "./style.css": "./dist/style/index.css",
     "./style/*.css": "./dist/style/*.css"
   },
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "tsconfig-examples.json",
@@ -92,6 +103,9 @@
       {
         "displayName": "node",
         "preset": "@forsakringskassan/jest-config",
+        "setupFiles": [
+          "<rootDir>/jest.setup.ts"
+        ],
         "testPathIgnorePatterns": [
           "/node_modules/",
           "<rootDir>/src/runtime"

--- a/src/assets/compile-script.ts
+++ b/src/assets/compile-script.ts
@@ -2,6 +2,7 @@ import nodeFS from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { type BuildOptions } from "esbuild";
+import { tsconfigPath as tsconfig } from "../tsconfig-path";
 import { getFingerprint, getIntegrity } from "../utils";
 import { VendorDefinition } from "../vendor";
 import { AssetInfo } from "./asset-info";
@@ -64,7 +65,7 @@ export async function compileScript(
             format,
             platform: "browser",
             external,
-            tsconfig: path.join(__dirname, "../tsconfig-examples.json"),
+            tsconfig,
             ...buildOptions,
             define: {
                 "process.env.DOCS_ICON_LIB": JSON.stringify(iconLib),

--- a/src/compile-example.ts
+++ b/src/compile-example.ts
@@ -1,12 +1,11 @@
-import path from "node:path";
 import { type Plugin, build as esbuild } from "esbuild";
 import { version } from "vue";
 import { vuePlugin as Vue3Plugin } from "plugin-vue3";
 import { virtualEntryPlugin } from "./esbuild";
 import { type ExampleCompileTask, type ExampleBatch } from "./examples";
+import { tsconfigPath as tsconfig } from "./tsconfig-path";
 
 const vueMajor = parseInt(version.split(".", 2)[0], 10) as 2 | 3;
-const tsconfig = path.join(__dirname, "../tsconfig-examples.json");
 
 function stripExtension(filename: string): string {
     return filename.replace(".js", "");

--- a/src/compile-processor-runtime.ts
+++ b/src/compile-processor-runtime.ts
@@ -26,7 +26,7 @@ export function compileProcessorRuntime(
                 entry.name ?? path.parse(entry.src).name,
             ].join("/");
             const name = processorRuntimeName(processor, entry);
-            const bundled = new URL(`${name}.js`, distDir);
+            const bundled = new URL(`${name}.mjs`, distDir);
             const scriptPath = existsSync(bundled) ? bundled : entry.src;
             generator.compileScript(
                 assetName,

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -327,7 +327,7 @@ export class Generator {
         this.sourceFiles = [];
         this.markdownOptions = options.markdown;
 
-        const bootstrapUrl = new URL("runtime-bootstrap.js", import.meta.url);
+        const bootstrapUrl = new URL("runtime-bootstrap.mjs", import.meta.url);
         this.compileScript(
             "bootstrap",
             bootstrapUrl,

--- a/src/render/find-template.ts
+++ b/src/render/find-template.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import { type DocumentPage, type FileInfo } from "../document";
+import { templateDirectory } from "./template-directory";
 
 class MissingTemplateError extends Error {
     private searchDir: string[];
@@ -27,7 +28,6 @@ class MissingTemplateError extends Error {
     }
 }
 
-const templateDirectory = path.join(__dirname, "../templates");
 const cache = new Map<string, string>();
 
 function cacheKey(layout: string, extension: "html" | "json"): string {

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { existsSync, copyFileSync, readFileSync } from "node:fs";
 import path from "node:path";
 import pathPosix from "node:path/posix";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import spawn from "nano-spawn";
 import nunjucks from "nunjucks";
@@ -39,7 +40,8 @@ interface ActiveNavigationSection extends NavigationSection {
 
 type ActiveNavigationNode = ActiveNavigationLeaf | ActiveNavigationSection;
 
-const scriptPath = path.join(__dirname, "compile-example.js");
+const scriptUrl = new URL("./compile-example.mjs", import.meta.url);
+const scriptPath = fileURLToPath(scriptUrl);
 let loader: TemplateLoader | null = null;
 
 function haveOutputFile(

--- a/src/render/template-directory.ts
+++ b/src/render/template-directory.ts
@@ -1,0 +1,4 @@
+import { fileURLToPath } from "node:url";
+
+const templateUrl = new URL("../templates", import.meta.url);
+export const templateDirectory = fileURLToPath(templateUrl);

--- a/src/render/template-loader.ts
+++ b/src/render/template-loader.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { type Callback, type ILoaderAsync, type LoaderSource } from "nunjucks";
+import { templateDirectory } from "./template-directory";
 
 interface ResolvedTemplate {
     filePath: string;
@@ -17,7 +18,7 @@ export class TemplateLoader implements ILoaderAsync {
     private readonly templateCache: Map<string, ResolvedTemplate>;
 
     public constructor(folders: string[] = []) {
-        this.folders = [...folders, path.join(__dirname, "../templates")];
+        this.folders = [...folders, templateDirectory];
         this.templateCache = new Map();
     }
 

--- a/src/tsconfig-path.ts
+++ b/src/tsconfig-path.ts
@@ -1,0 +1,4 @@
+import { fileURLToPath } from "node:url";
+
+const path = new URL("../tsconfig-examples.json", import.meta.url);
+export const tsconfigPath = fileURLToPath(path);

--- a/src/vendor/compile-vendor.ts
+++ b/src/vendor/compile-vendor.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import esbuild, { type BuildOptions } from "esbuild";
+import { tsconfigPath as tsconfig } from "../tsconfig-path";
 import { getFingerprint, getIntegrity, slugify } from "../utils";
 import { type VendorAsset } from "./vendor-asset";
 import { type NormalizedVendorDefinition } from "./vendor-definition";
@@ -29,7 +30,6 @@ export async function compileVendor(
     const outfile = `temp/vendor-${slug}.out.js`;
     const tmpfile = `temp/vendor-${slug}.in.js`;
     const source = getAssetSource(vendor);
-    const tsconfig = path.resolve(__dirname, "../tsconfig-examples.json");
     await fs.writeFile(tmpfile, source, "utf-8");
     await esbuild.build({
         entryPoints: [tmpfile],


### PR DESCRIPTION
Prerequisite for #218, or it simplifies a few things at least.

Strictly the `.mjs` and `.d.mts` change is not required but during implementation it helped to keep track of what ran as ESM and what was stil CommonJS, decided to just keep it but could switch it back to just `.js` and `.d.ts` as `type` is now `module` for the entire package anyway.