### PR TITLE
feat: `Generator()` constructor takes `import.meta.url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import {
     livereloadProcessor,
 } from "@forsakringskassan/docs-generator";
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     site: {
         name: "My Awesome Site",
     },
@@ -41,7 +41,7 @@ import {
     livereloadProcessor,
 } from "@forsakringskassan/docs-generator";
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     site: {
         name: "My Awesome Site",
     },
@@ -117,7 +117,7 @@ Style can be compiled with `compileStyle(name, src, [options])`:
 ```ts
 import { Generator } from "@forsakringskassan/docs-generator";
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     site: {
         name: "My Awesome Site",
     },
@@ -304,7 +304,7 @@ for (const entry of Object.values(icons)) {
 ### Matomo
 
 ```diff
- const docs = new Generator({
+ const docs = new Generator(import.meta.url, {
      processors: [
 +        matomoProcessor({
 +            siteId: "1",
@@ -318,7 +318,7 @@ for (const entry of Object.values(icons)) {
 Optionally set `hostname` to limit which hostnames can run Matomo analytics:
 
 ```diff
- const docs = new Generator({
+ const docs = new Generator(import.meta.url, {
      processors: [
          matomoProcessor({
              siteId: "1",

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,7 +6,7 @@ import { type Manifest, Generator } from "./dist";
 import config from "./docs.config.mjs";
 
 async function getDocsPages(): Promise<Manifest["pages"]> {
-    const docs = new Generator({
+    const docs = new Generator(import.meta.url, {
         site: {
             name: "FK Documentation generator",
             lang: "en",

--- a/docs/layout/overriding-templates.md
+++ b/docs/layout/overriding-templates.md
@@ -12,7 +12,7 @@ import { Generator } from "@forsakringskassan/docs-generator";
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/markdown/api/vue.md
+++ b/docs/markdown/api/vue.md
@@ -13,7 +13,7 @@ import {
     vueFileReader,
 } from "@forsakringskassan/docs-generator";
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     site: { name: "My Awesome Site" },
     setupPath: "setup.ts",
 });

--- a/docs/markdown/containers/details.md
+++ b/docs/markdown/containers/details.md
@@ -69,7 +69,7 @@ import { Generator } from "@forsakringskassan/docs-generator";
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/markdown/containers/messagebox.md
+++ b/docs/markdown/containers/messagebox.md
@@ -185,7 +185,7 @@ import { Generator } from "@forsakringskassan/docs-generator";
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/navigation/index.md
+++ b/docs/navigation/index.md
@@ -31,7 +31,7 @@ import {
     navigationFileReader,
 } from "@forsakringskassan/docs-generator";
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     site: { name: "" },
     setupPath: "docs/src/setup.ts",
 });

--- a/docs/processors/cookie.md
+++ b/docs/processors/cookie.md
@@ -13,7 +13,7 @@ import { Generator, cookieProcessor } from "@forsakringskassan/docs-generator";
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/processors/extract-examples.md
+++ b/docs/processors/extract-examples.md
@@ -52,7 +52,7 @@ import {
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/processors/manifest.md
+++ b/docs/processors/manifest.md
@@ -24,7 +24,7 @@ const config = {
         /* ... */
     ],
 };
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",
@@ -45,7 +45,7 @@ import {
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/processors/motd.md
+++ b/docs/processors/motd.md
@@ -32,7 +32,7 @@ import { Generator, motdProcessor } from "@forsakringskassan/docs-generator";
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",
@@ -50,7 +50,7 @@ import { Generator, motdProcessor } from "@forsakringskassan/docs-generator";
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/processors/search.md
+++ b/docs/processors/search.md
@@ -21,7 +21,7 @@ import { Generator, searchProcessor } from "@forsakringskassan/docs-generator";
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/processors/source-url.md
+++ b/docs/processors/source-url.md
@@ -23,7 +23,7 @@ import {
 
 const pkg = JSON.parse(await fs.readFile("package.json", "utf-8"));
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/processors/topnav.md
+++ b/docs/processors/topnav.md
@@ -13,7 +13,7 @@ import { Generator, topnavProcessor } from "@forsakringskassan/docs-generator";
 
 /* --- cut above --- */
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/docs/processors/version.md
+++ b/docs/processors/version.md
@@ -15,7 +15,7 @@ import { Generator, versionProcessor } from "@forsakringskassan/docs-generator";
 
 const pkg = JSON.parse(await fs.readFile("package.json", "utf-8"));
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     /* --- cut begin --- */
     site: { name: ".." },
     setupPath: "..",

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -116,7 +116,9 @@ export function frontMatterFileReader(filePath: string, basePath?: string): Prom
 
 // @public (undocumented)
 class Generator_2 {
+    // @deprecated
     constructor(options: GeneratorOptions);
+    constructor(importMetaUrl: string | URL, options: GeneratorOptions);
     // (undocumented)
     build(sourceFiles: SourceFiles[]): Promise<string[]>;
     // (undocumented)

--- a/generate-docs.mjs
+++ b/generate-docs.mjs
@@ -19,7 +19,7 @@ import config from "./docs.config.mjs";
 const isRelease = Boolean(process.env.RELEASE);
 const pkg = JSON.parse(await fs.readFile("./package.json", "utf-8"));
 
-const docs = new Generator({
+const docs = new Generator(import.meta.url, {
     site: {
         name: "FK Documentation generator",
         lang: "en",

--- a/src/utils/normalize-path.ts
+++ b/src/utils/normalize-path.ts
@@ -5,5 +5,8 @@ import path from "node:path/posix";
  */
 export function normalizePath(...pathSegments: string[]): string {
     const filePath = path.join(...pathSegments);
-    return path.normalize(filePath).replace(/\\/g, "/");
+    return path
+        .normalize(filePath)
+        .replace(/^([A-Z]):\\/, "/")
+        .replace(/\\/g, "/");
 }


### PR DESCRIPTION
Passar in sökvägen till katalogen man vill bygga från. Underlättar för att skapa sökvägar relativa till den katalogen istället för att jobba med absoluta sökvägar.

Som vanligt är Windows det stora problemet därav hacken med att försöka normalizera. Provkörs i fjärrskrivbort med MSYS2, Git Bash och Powershell och vad jag kan se så får man ut ok resultat från detta. (`fs.stat(this.cwd)` gav korrekt resultat)

Fungerar om man inte passar in sökvägen men då får man en varning om deprekerat beteende.