### PR TITLE
fix: `margin` between headers and other elements (fixes SFKUI-7489)

### DIFF
--- a/src/style/_typography.scss
+++ b/src/style/_typography.scss
@@ -85,6 +85,26 @@
     margin-top: 1rem;
 }
 
+:where(.docs-heading--h2 + .docs-heading--h3) {
+    margin-top: 2rem;
+}
+
+:where(.docs-paragraph + .docs-heading--h2) {
+    margin-top: 3.5rem;
+}
+
+:where(.docs-paragraph + .docs-heading--h3) {
+    margin-top: 3rem;
+}
+
+:where(.code-preview + .docs-heading--h3) {
+    margin-top: 3rem;
+}
+
+:where(.code-preview + .docs-paragraph) {
+    margin-top: 3rem;
+}
+
 @media (width <=$breakpoint-sm) {
     :where(.docs-heading--h1) {
         font-size: 1.75rem;


### PR DESCRIPTION
## Kravspecifikation
Det ska vara samma systematik på rubriker och avstånd som för fk.se.

## Implementation
Jag har läst den interna implementationen och försökt återskapa så gott jag kan.
Jag är dock inget proffs på CSS/Sass; det finns därför kommenterarer som refererar den interna implementationen.