### PR TITLE
fix: populate child elements when using `topnavProcessor`

### DIFF
--- a/src/processors/topnav-processor.spec.ts
+++ b/src/processors/topnav-processor.spec.ts
@@ -1,3 +1,4 @@
+import { type NavigationSection } from "../navigation";
 import { type TopnavEntry, generateNavigation } from "./topnav-processor";
 
 it("should generate navigation nodes for each entry", () => {
@@ -6,7 +7,15 @@ it("should generate navigation nodes for each entry", () => {
         { path: "./foo", title: "Foo" },
         { path: "./bar", title: "Bar" },
     ];
-    const rootNode = generateNavigation(entries);
+    const navtree: NavigationSection = {
+        key: ".",
+        title: "",
+        path: "",
+        sortorder: Infinity,
+        children: [],
+        visible: true,
+    };
+    const rootNode = generateNavigation(entries, navtree);
     expect(rootNode.children).toEqual([
         {
             key: "foo",
@@ -32,7 +41,15 @@ it("should override properties", () => {
     const entries: TopnavEntry[] = [
         { path: "./foo", title: "Foo", sortorder: 1, visible: false },
     ];
-    const rootNode = generateNavigation(entries);
+    const navtree: NavigationSection = {
+        key: ".",
+        title: "",
+        path: "",
+        sortorder: Infinity,
+        children: [],
+        visible: true,
+    };
+    const rootNode = generateNavigation(entries, navtree);
     expect(rootNode.children).toEqual([
         {
             key: "foo",
@@ -41,6 +58,102 @@ it("should override properties", () => {
             sortorder: 1,
             children: [],
             visible: false,
+        },
+    ]);
+});
+
+it("should merge children with existing navigation items", () => {
+    expect.assertions(1);
+    const entries: TopnavEntry[] = [
+        { path: "./foo", title: "Foo", sortorder: 0 },
+        { path: "./bar", title: "Bar", sortorder: 2 },
+    ];
+    const navtree: NavigationSection = {
+        key: ".",
+        title: "",
+        path: "",
+        sortorder: Infinity,
+        children: [
+            {
+                key: "foo",
+                title: "Foo",
+                path: "./old-foo",
+                sortorder: 5,
+                visible: true,
+                children: [
+                    {
+                        title: "Foo Child",
+                        path: "./foo-child",
+                        sortorder: 0,
+                        id: "foo-child",
+                        external: false,
+                    },
+                ],
+            },
+            {
+                key: "baz",
+                title: "Baz",
+                path: "./baz",
+                sortorder: 1,
+                visible: true,
+                children: [],
+            },
+        ],
+        visible: true,
+    };
+
+    const rootNode = generateNavigation(entries, navtree);
+    expect(rootNode.children).toEqual([
+        {
+            key: "foo",
+            title: "Foo",
+            path: "./foo",
+            sortorder: 0,
+            visible: true,
+            children: [
+                {
+                    title: "Foo Child",
+                    path: "./foo-child",
+                    sortorder: 0,
+                    id: "foo-child",
+                    external: false,
+                },
+            ],
+        },
+        {
+            key: "bar",
+            title: "Bar",
+            path: "./bar",
+            sortorder: 2,
+            visible: true,
+            children: [],
+        },
+    ]);
+});
+
+it("should handle new entries not present in existing navigation", () => {
+    expect.assertions(1);
+    const entries: TopnavEntry[] = [
+        { path: "./new-entry", title: "New Entry", sortorder: 0 },
+    ];
+    const navtree: NavigationSection = {
+        key: ".",
+        title: "",
+        path: "",
+        sortorder: Infinity,
+        children: [],
+        visible: true,
+    };
+
+    const rootNode = generateNavigation(entries, navtree);
+    expect(rootNode.children).toEqual([
+        {
+            key: "new-entry",
+            title: "New Entry",
+            path: "./new-entry",
+            sortorder: 0,
+            visible: true,
+            children: [],
         },
     ]);
 });

--- a/src/processors/topnav-processor.ts
+++ b/src/processors/topnav-processor.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path/posix";
+import { isDocumentPage } from "../document";
 import { type NavigationSection } from "../navigation";
+import { generateNavtree } from "../navigation/generate-navtree";
 import { type Processor } from "../processor";
 
 /**
@@ -20,23 +22,39 @@ export interface TopnavEntry {
  */
 export function generateNavigation(
     entries: TopnavEntry[],
+    navtree: NavigationSection,
 ): Omit<NavigationSection, "title"> {
-    const children = entries.map((it, index): NavigationSection => {
-        const key = path.parse(it.path).name;
-        return {
-            key,
-            sortorder: index,
-            children: [],
-            visible: true,
-            ...it,
-        };
-    });
     return {
         key: ".",
         path: "./index.html",
         sortorder: Infinity,
-        children,
         visible: true,
+        children: entries
+            .map((entry, index) => {
+                // Find the corresponding item in navtree
+                const navtreeItem = navtree.children.find(
+                    (item) => item.title === entry.title,
+                );
+
+                if (navtreeItem) {
+                    return {
+                        ...navtreeItem,
+                        path: entry.path,
+                        sortorder: entry.sortorder ?? index,
+                    };
+                }
+
+                const key = path.parse(entry.path).name;
+                // Create a new NavigationLeaf for entries not in navtree
+                return {
+                    key,
+                    sortorder: index,
+                    children: [],
+                    visible: true,
+                    ...entry,
+                };
+            })
+            .toSorted((a, b) => a.sortorder - b.sortorder),
     };
 }
 
@@ -56,7 +74,10 @@ export function topnavProcessor(filename: string, title: string): Processor {
         async handler(context) {
             const content = await fs.readFile(filename, "utf8");
             const parsed = JSON.parse(content) as TopnavEntry[];
-            const rootNode = generateNavigation(parsed);
+            const pages = context.docs.filter(isDocumentPage);
+            const navtree = generateNavtree(pages);
+            const rootNode = generateNavigation(parsed, navtree);
+
             context.setTopNavigation({
                 title,
                 ...rootNode,


### PR DESCRIPTION
Bryter ut från #387 