### PR TITLE
fix: sort navigation tree by default

### DIFF
--- a/src/navigation/navigation-processor.ts
+++ b/src/navigation/navigation-processor.ts
@@ -1,6 +1,7 @@
 import { isDocumentPage } from "../document";
 import { type Processor } from "../processor";
 import { generateNavtree } from "./generate-navtree";
+import { sortNavigationTree } from "./sort-navigation-tree";
 
 export function navigationProcessor(): Processor {
     return {
@@ -9,6 +10,7 @@ export function navigationProcessor(): Processor {
         handler(context) {
             const pages = context.docs.filter(isDocumentPage);
             const navtree = generateNavtree(pages);
+            sortNavigationTree(navtree);
             context.setTopNavigation(navtree);
             context.setSideNavigation(navtree);
         },


### PR DESCRIPTION
Sidenav is already being sorted, in practice this affects topnav only (when not using [`topnavProcessor()`](https://forsakringskassan.github.io/docs-generator/latest/processors/topnav.html)  to manually override the topmenu).

fixes #416