### PR TITLE
add additional data to manifest

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,7 +12,7 @@ async function getDocsPages(): Promise<Manifest["pages"]> {
             name: "FK Documentation generator",
             lang: "en",
         },
-        setupPath: "",
+        exampleFolders: ["./docs", "./src"],
     });
     const manifest = await docs.manifest(config.sourceFiles);
     return manifest.pages.filter((it) => {

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -121,6 +121,9 @@ export interface FileInfo {
 }
 
 // @public
+export type FileMatcher = (filename: string, context?: string) => string;
+
+// @public
 type FileReader_2 = (filePath: string, basePath?: string) => Promise<Document_2[]>;
 export { FileReader_2 as FileReader }
 
@@ -194,6 +197,7 @@ export interface Manifest {
         }>;
         examples: Array<{
             name?: string;
+            src: string | null;
             selector: string;
             language: string;
             tags: string[];
@@ -318,6 +322,7 @@ export interface ProcessorContext {
     // (undocumented)
     readonly docs: Document_2[];
     error(...args: unknown[]): void;
+    readonly exampleFileMatcher: FileMatcher;
     // @internal (undocumented)
     getAllTemplateBlocks(): Map<string, Array<TemplateBlockData<unknown>>>;
     // (undocumented)

--- a/etc/index.api.md
+++ b/etc/index.api.md
@@ -189,6 +189,7 @@ export interface Manifest {
     // (undocumented)
     pages: Array<{
         path: string;
+        src: string;
         title: string;
         redirect: null | string;
         outline: Array<{

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -491,7 +491,9 @@ export class Generator {
         await stage("generate-docs", context, processors, { verbose: false });
 
         const docs = context.docs.filter(isDocumentPage).filter(haveOutput);
-        const pages = docs.map(manifestPageFromDocument);
+        const pages = docs.map((doc) => {
+            return manifestPageFromDocument({ exampleFileMatcher }, doc);
+        });
         return { pages };
     }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -34,7 +34,12 @@ import { redirectProcessor } from "./processors";
 import { type TemplateLoader, nunjucksProcessor } from "./render";
 import { createTemplateLoader } from "./render/render";
 import { serve } from "./serve";
-import { fileMatcher, haveOutput, normalizePath } from "./utils";
+import {
+    type FileMatcher,
+    fileMatcher,
+    haveOutput,
+    normalizePath,
+} from "./utils";
 import {
     type VendorAsset,
     type VendorDefinition,
@@ -202,10 +207,12 @@ async function stage(
 }
 /* eslint-enable no-console */
 
-function createContext(
-    outputFolder: string,
-    templateLoader: TemplateLoader,
-): Omit<ProcessorContext, "log" | "error"> {
+function createContext(options: {
+    outputFolder: string;
+    exampleFileMatcher: FileMatcher;
+    templateLoader: TemplateLoader;
+}): Omit<ProcessorContext, "log" | "error"> {
+    const { outputFolder, exampleFileMatcher, templateLoader } = options;
     let docs: Document[] = [];
     let vendors: VendorAsset[] = [];
     const resources: ResourceTask[] = [];
@@ -249,6 +256,7 @@ function createContext(
         },
 
         outputFolder,
+        exampleFileMatcher,
 
         addDocument(document: Document | Document[]) {
             docs = [...docs, ...toArray(document)];
@@ -472,8 +480,14 @@ export class Generator {
             ...this.processors,
         ];
 
+        const examplePatterns = this.exampleFolders.map((it) => `${it}/**/*`);
+        const exampleFileMatcher = fileMatcher(examplePatterns);
         const templateLoader = createTemplateLoader([]);
-        const context = createContext("", templateLoader);
+        const context = createContext({
+            outputFolder: "",
+            exampleFileMatcher,
+            templateLoader,
+        });
         await stage("generate-docs", context, processors, { verbose: false });
 
         const docs = context.docs.filter(isDocumentPage).filter(haveOutput);
@@ -529,7 +543,6 @@ export class Generator {
                 templateFolders,
                 setupPath,
                 markdown: markdownOptions ?? {},
-                fileMatcher: fileMatcher(examplePatterns),
             }),
             ...this.processors,
         ];
@@ -537,7 +550,11 @@ export class Generator {
         compileProcessorRuntime(this, import.meta.url, processors);
 
         const templateLoader = createTemplateLoader(templateFolders);
-        const context = createContext(outputFolder, templateLoader);
+        const context = createContext({
+            outputFolder,
+            exampleFileMatcher: fileMatcher(examplePatterns),
+            templateLoader,
+        });
         const generatedFiles = [
             await stage("generate-docs", context, processors),
             await stage("generate-nav", context, processors),

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,12 @@ export {
 export { searchProcessor } from "./search";
 export { livereloadProcessor } from "./serve";
 export { type SetupOptions } from "./setup-options";
-export { type AttributeTable, type AttributeValue, isRelease } from "./utils";
+export {
+    type AttributeTable,
+    type AttributeValue,
+    type FileMatcher,
+    isRelease,
+} from "./utils";
 export {
     type VendorAsset,
     type VendorDefinition,

--- a/src/manifest/manifest-page-from-document.ts
+++ b/src/manifest/manifest-page-from-document.ts
@@ -79,6 +79,7 @@ export function manifestPageFromDocument(doc: DocumentPageLike): ManifestPage {
     const { body, fileInfo, format } = doc;
     return {
         path: getOutputFilePath("", fileInfo),
+        src: doc.fileInfo.fullPath,
         title: doc.attributes.title ?? doc.name,
         redirect: format === "redirect" ? body : null,
         outline: flattenOutline(doc.outline),

--- a/src/manifest/manifest-page-from-document.ts
+++ b/src/manifest/manifest-page-from-document.ts
@@ -1,7 +1,15 @@
 import markdownIt from "markdown-it";
 import { type DocumentOutline, type DocumentPage } from "../document";
 import { parseInfostring } from "../examples";
-import { findTag, getFingerprint, getOutputFilePath, hasTag } from "../utils";
+import { type ProcessorContext } from "../processor-context";
+import {
+    type FileMatcher,
+    findTag,
+    getFingerprint,
+    getOutputFilePath,
+    hasTag,
+    parseImport,
+} from "../utils";
 import { type Manifest } from "./manifest";
 
 type DocumentPageWithOutput = DocumentPage & {
@@ -15,20 +23,27 @@ type ManifestPage = Manifest["pages"][number];
 type ManifestOutline = ManifestPage["outline"];
 type ManifestExamples = ManifestPage["examples"];
 
+interface MarkdownEnv {
+    readonly collected: ManifestExamples;
+    readonly exampleFileMatcher: FileMatcher;
+}
+
 const md = markdownIt();
 
 md.renderer.rules.fence = (
     tokens,
     idx,
     _options,
-    collected: ManifestExamples,
+    env: MarkdownEnv,
     /* eslint-disable-next-line sonarjs/no-invariant-returns -- function works as intended */
 ) => {
+    const { collected, exampleFileMatcher } = env;
     const { content, info, map } = tokens[idx];
     const { language: rawLanguage, tags } = parseInfostring(info);
     const hashContent = `${String(map?.[0])}:${String(map?.[1])}:${info}:${content}`;
     const fingerprint = getFingerprint(hashContent);
     let extension = undefined;
+    let src: string | null = null;
     let language = rawLanguage;
 
     if (hasTag(tags, "compare")) {
@@ -36,7 +51,9 @@ md.renderer.rules.fence = (
     }
 
     if (language === "import") {
-        extension = content.split(".").at(-1)?.trim();
+        const parsed = parseImport(content);
+        src = exampleFileMatcher(parsed.filename);
+        extension = parsed.extension;
     }
 
     if (hasTag(tags, "hidden")) {
@@ -47,6 +64,7 @@ md.renderer.rules.fence = (
 
     collected.push({
         name,
+        src,
         selector: `#example-${fingerprint}`,
         language: extension ?? language,
         tags,
@@ -63,19 +81,29 @@ function flattenOutline(outline: DocumentOutline): ManifestOutline {
     });
 }
 
-function findExamples(doc: DocumentPageLike): ManifestExamples {
+function findExamples(
+    context: Pick<ProcessorContext, "exampleFileMatcher">,
+    doc: DocumentPageLike,
+): ManifestExamples {
+    const { exampleFileMatcher } = context;
     if (doc.format !== "markdown") {
         return [];
     }
     const collected: ManifestExamples = [];
-    md.render(doc.body, collected);
+    md.render(doc.body, {
+        exampleFileMatcher,
+        collected,
+    } satisfies MarkdownEnv);
     return collected;
 }
 
 /**
  * @internal
  */
-export function manifestPageFromDocument(doc: DocumentPageLike): ManifestPage {
+export function manifestPageFromDocument(
+    context: Pick<ProcessorContext, "exampleFileMatcher">,
+    doc: DocumentPageLike,
+): ManifestPage {
     const { body, fileInfo, format } = doc;
     return {
         path: getOutputFilePath("", fileInfo),
@@ -83,6 +111,6 @@ export function manifestPageFromDocument(doc: DocumentPageLike): ManifestPage {
         title: doc.attributes.title ?? doc.name,
         redirect: format === "redirect" ? body : null,
         outline: flattenOutline(doc.outline),
-        examples: findExamples(doc),
+        examples: findExamples(context, doc),
     };
 }

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -11,6 +11,8 @@ export interface Manifest {
         outline: Array<{ heading: string; anchor: string }>;
         examples: Array<{
             name?: string;
+            /** Path to imported example file (relative to project root) or `null` if example is inline */
+            src: string | null;
             selector: string;
             language: string;
             tags: string[];

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -4,6 +4,8 @@
 export interface Manifest {
     pages: Array<{
         path: string;
+        /** Path to the source document (relative to the project root) */
+        src: string;
         title: string;
         redirect: null | string;
         outline: Array<{ heading: string; anchor: string }>;

--- a/src/processor-context.ts
+++ b/src/processor-context.ts
@@ -1,6 +1,7 @@
 import { type ResourceTask } from "./assets";
 import { type Document } from "./document";
 import { type NavigationSection } from "./navigation";
+import { type FileMatcher } from "./utils";
 import { type VendorAsset } from "./vendor";
 
 /**
@@ -67,6 +68,11 @@ export interface ProcessorContext {
         id: string,
         renderer: TemplateBlockRenderer<T>,
     ): void;
+
+    /**
+     * A `fileMatcher()` instance for finding imported examples.
+     */
+    readonly exampleFileMatcher: FileMatcher;
 
     /**
      * @internal

--- a/src/processors/api-extractor/__fixtures__/model.api.json
+++ b/src/processors/api-extractor/__fixtures__/model.api.json
@@ -131,48 +131,10 @@
           "syntaxKind": "block"
         },
         {
-          "tagName": "@betaDocumentation",
-          "syntaxKind": "modifier"
-        },
-        {
-          "tagName": "@internalRemarks",
+          "tagName": "@since",
           "syntaxKind": "block"
-        },
-        {
-          "tagName": "@preapproved",
-          "syntaxKind": "modifier"
         }
       ],
-      "supportForTags": {
-        "@alpha": true,
-        "@beta": true,
-        "@defaultValue": true,
-        "@decorator": true,
-        "@deprecated": true,
-        "@eventProperty": true,
-        "@example": true,
-        "@experimental": true,
-        "@inheritDoc": true,
-        "@internal": true,
-        "@label": true,
-        "@link": true,
-        "@override": true,
-        "@packageDocumentation": true,
-        "@param": true,
-        "@privateRemarks": true,
-        "@public": true,
-        "@readonly": true,
-        "@remarks": true,
-        "@returns": true,
-        "@sealed": true,
-        "@see": true,
-        "@throws": true,
-        "@typeParam": true,
-        "@virtual": true,
-        "@betaDocumentation": true,
-        "@internalRemarks": true,
-        "@preapproved": true
-      },
       "reportUnsupportedHtmlElements": false
     }
   },

--- a/src/processors/api-extractor/api-extractor-processor.spec.ts
+++ b/src/processors/api-extractor/api-extractor-processor.spec.ts
@@ -35,6 +35,9 @@ function createMockContext(): ProcessorContext {
                 docs.push(doc);
             }
         },
+        exampleFileMatcher() {
+            return "";
+        },
         topnav: {
             key: "root",
             title: "Root",

--- a/src/processors/manifest-processor.ts
+++ b/src/processors/manifest-processor.ts
@@ -86,7 +86,9 @@ export function manifestProcessor(
         before: "render",
         async handler(context) {
             const docs = context.docs.filter(isDocumentPage).filter(haveOutput);
-            const pages = docs.map(manifestPageFromDocument);
+            const pages = docs.map((doc) =>
+                manifestPageFromDocument(context, doc),
+            );
             pages.sort((a, b) => {
                 return a.path.localeCompare(b.path);
             });

--- a/src/render/nunjucks-processor.ts
+++ b/src/render/nunjucks-processor.ts
@@ -23,14 +23,16 @@ export function nunjucksProcessor(
         name: "nunjucks-renderer",
         async handler(context) {
             function renderDocument(doc: DocumentPage): Promise<string | null> {
-                const nav = {
-                    topnav: context.topnav,
-                    sidenav: context.sidenav,
-                };
-                return render(doc, context.docs, nav, context.vendors, {
+                return render(doc, context.docs, {
                     ...options,
+                    exampleFileMatcher: context.exampleFileMatcher,
+                    nav: {
+                        topnav: context.topnav,
+                        sidenav: context.sidenav,
+                    },
                     templateBlocks: context.getAllTemplateBlocks(),
                     templateData: context.getAllTemplateData(),
+                    vendors: context.vendors,
                     addResource(dst, src) {
                         context.addResource(dst, src);
                     },

--- a/src/render/render-options.ts
+++ b/src/render/render-options.ts
@@ -28,7 +28,4 @@ export interface RenderOptions {
     };
 
     addResource(this: void, dst: string, src: string): void;
-
-    /** A previously constructed fileMatcher() */
-    fileMatcher(this: void, filename: string, context?: string): string;
 }

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -22,7 +22,7 @@ import {
     isNavigationSection,
     sortNavigationTree,
 } from "../navigation";
-import { getFingerprint, getOutputFilePath } from "../utils";
+import { type FileMatcher, getFingerprint, getOutputFilePath } from "../utils";
 import { type VendorAsset } from "../vendor";
 import { createMarkdownRenderer } from "./create-markdown-renderer";
 import * as filter from "./filter";
@@ -228,13 +228,25 @@ function stripPrettierComments(content: string): string {
 export async function render(
     doc: DocumentPage,
     docs: Document[],
-    nav: { topnav: NavigationSection; sidenav: NavigationSection },
-    vendors: VendorAsset[],
-    options: RenderOptions,
+    options: RenderOptions & {
+        readonly exampleFileMatcher: FileMatcher;
+        readonly nav: {
+            readonly topnav: NavigationSection;
+            readonly sidenav: NavigationSection;
+        };
+        readonly vendors: VendorAsset[];
+    },
 ): Promise<string | null> {
     const { fileInfo } = doc;
-    const { i18n, outputFolder, cacheFolder, templateFolders, fileMatcher } =
-        options;
+    const {
+        i18n,
+        outputFolder,
+        cacheFolder,
+        exampleFileMatcher,
+        nav,
+        templateFolders,
+        vendors,
+    } = options;
 
     /* skip rendering files which have no output */
     if (!haveOutputFile(fileInfo)) {
@@ -310,7 +322,7 @@ export async function render(
                 setupPath: options.setupPath,
                 exampleFolders: options.exampleFolders,
                 tags,
-                fileMatcher,
+                fileMatcher: exampleFileMatcher,
             });
 
             if (example.output) {
@@ -328,7 +340,7 @@ export async function render(
         },
         getImportedSource(filename) {
             const context = `when importing example from "${fileInfo.fullPath}"`;
-            const match = fileMatcher(filename, context);
+            const match = exampleFileMatcher(filename, context);
             return readFileSync(match, "utf8");
         },
         addResource(dst, src) {

--- a/src/utils/file-matcher.ts
+++ b/src/utils/file-matcher.ts
@@ -3,6 +3,18 @@ import { globSync } from "glob";
 import { memoize } from "./memoize";
 
 /**
+ * A function to search for a filename.
+ *
+ * @public
+ * @since %version%
+ * @param filename - The filename to search for
+ * @param context - An optional context for usage in error messages
+ * @throws Throws an error if the filename could not be found
+ * @returns Filename relative to project root
+ */
+export type FileMatcher = (filename: string, context?: string) => string;
+
+/**
  * Create a matcher which returns the full path given a filename, partial path
  * to a filename or glob pattern.
  *
@@ -11,9 +23,7 @@ import { memoize } from "./memoize";
  * @internal
  * @param patterns - Glob patterns to match all possible files.
  */
-export function fileMatcher(
-    patterns: string[],
-): (filename: string, context?: string) => string {
+export function fileMatcher(patterns: string[]): FileMatcher {
     const fileList = globSync(patterns, {
         posix: true,
         ignore: "**/node_modules/**",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { createMockDocument } from "./create-mock-document";
-export { fileMatcher } from "./file-matcher";
+export { type FileMatcher, fileMatcher } from "./file-matcher";
 export { findDocument } from "./find-document";
 export { findTag } from "./find-tag";
 export { formatSize } from "./format-size";

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+    "tagDefinitions": [
+        {
+            "tagName": "@since",
+            "syntaxKind": "block"
+        }
+    ]
+}


### PR DESCRIPTION
* The original path to the markdown document
* The original path to the imported example

This is needed to create a documentation package to use when including documents into third party sites.

Only thing missing is the dependencies of the imported examples