### PR TITLE
fix: declare TypeScript as runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "semver": "7.8.1",
         "synckit": "0.11.13",
         "tiny-lr": "2.0.0",
+        "typescript": "6.0.3",
         "vue-docgen-api": "4.79.2"
       },
       "devDependencies": {
@@ -94,8 +95,7 @@
         "rollup-plugin-esbuild": "6.2.1",
         "rollup-plugin-visualizer": "7.0.1",
         "sass": "1.100.0",
-        "ts-node": "10.9.2",
-        "typescript": "6.0.3"
+        "ts-node": "10.9.2"
       },
       "engines": {
         "node": "^22.16 || >= 24"
@@ -16841,7 +16841,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "semver": "7.8.1",
     "synckit": "0.11.13",
     "tiny-lr": "2.0.0",
+    "typescript": "6.0.3",
     "vue-docgen-api": "4.79.2"
   },
   "devDependencies": {
@@ -203,8 +204,7 @@
     "rollup-plugin-esbuild": "6.2.1",
     "rollup-plugin-visualizer": "7.0.1",
     "sass": "1.100.0",
-    "ts-node": "10.9.2",
-    "typescript": "6.0.3"
+    "ts-node": "10.9.2"
   },
   "peerDependencies": {
     "esbuild": "0.x",


### PR DESCRIPTION
## Summary

Fixes #410.

`@forsakringskassan/docs-generator` bundles `esbuild-plugin-vue3` into the generated `dist/vue3-*.mjs` chunk. That plugin requires `typescript` at runtime, but `typescript` was only declared as a dev dependency, so clean consumer installs do not include it and fail with `Cannot find module 'typescript'`.

This moves the existing pinned `typescript@6.0.3` entry from `devDependencies` to `dependencies` so consumers receive the runtime dependency needed by the bundled Vue plugin.

## Validation

- `npm ci --ignore-scripts`
- `npm run build`
- `npm test -- --runInBand`
- `npm pack --ignore-scripts --json`
- Clean temp install from the packed tarball confirmed:
  - packed `package.json` has `dependencies.typescript = 6.0.3`
  - `typescript` resolves from a consumer install through `@forsakringskassan/docs-generator`
  - the issue #410 repro no longer emits `Cannot find module 'typescript'` or `MODULE_NOT_FOUND`
