### PR TITLE
fix: handle when `exampleFolders` contains paths from a parent folder

### DIFF
--- a/src/utils/file-matcher.spec.ts
+++ b/src/utils/file-matcher.spec.ts
@@ -21,6 +21,20 @@ it("should match by partial path", () => {
     expect(match("foo/bar.ts")).toBe("src/foo/bar.ts");
 });
 
+it("should match with glob", () => {
+    expect.assertions(1);
+    globSync.mockReturnValue(["src/foo/bar.ts"]);
+    const match = fileMatcher(["src/**"]);
+    expect(match("**/bar.ts")).toBe("src/foo/bar.ts");
+});
+
+it("should match in parent directory", () => {
+    expect.assertions(1);
+    globSync.mockReturnValue(["../../src/foo/bar.ts"]);
+    const match = fileMatcher(["../../src/**"]);
+    expect(match("bar.ts")).toBe("../../src/foo/bar.ts");
+});
+
 it("should throw when no files match", () => {
     expect.assertions(1);
     globSync.mockReturnValue([]);

--- a/src/utils/file-matcher.ts
+++ b/src/utils/file-matcher.ts
@@ -5,6 +5,12 @@ import { memoize } from "./memoize";
 /**
  * A function to search for a filename.
  *
+ * The filename can optionally include subdirectories or glob patterns:
+ *
+ * - `foo.ts` searches for `foo.ts` anywhere.
+ * - `bar/foo.ts` searches for `foo` in any `bar` directory.
+ * - `bar/**\/foo.ts` searches `foo` anywhere in an `bar` directory.
+ *
  * @public
  * @since %version%
  * @param filename - The filename to search for
@@ -31,7 +37,10 @@ export function fileMatcher(patterns: string[]): FileMatcher {
 
     return memoize((filename: string, context?: string) => {
         const matches = fileList.filter((file) => {
-            return path.matchesGlob(file, `**/${filename}`);
+            /* if the path starts with `../` we strip it out before matching or
+             * `path.matchesGlob()` wont match */
+            const stem = file.replace(/^(\.\.\/)+/, "");
+            return path.matchesGlob(stem, `**/${filename}`);
         });
         if (matches.length === 0) {
             const additionalInfo = context ? ` (${context})` : "";


### PR DESCRIPTION
Idag kan inte exempel resolvas om man har `exampleFolder: ["../foo"]`, det verkar bara vara så `path.matchesGlob()` fungerar. Hittar inget skrivet om det men har inte grävt jättedjupt heller.