### PR TITLE
feat: automatically include required runtime scripts

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -173,7 +173,8 @@ async function build() {
     const result = await esbuild.build({
         entryPoints: [
             { in: "src/runtime/bootstrap.ts", out: "runtime-bootstrap" },
-            { in: "src/runtime/index.ts", out: "runtime" },
+            { in: "src/runtime/index.ts", out: "runtime-internal" },
+            { in: "src/runtime/stub.ts", out: "runtime" },
             ...processorScripts,
         ],
         bundle: true,

--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -1,2 +1,0 @@
-/* eslint-disable-next-line import-x/extensions -- needed for import to resolve */
-import "../../dist/runtime.mjs";

--- a/generate-docs.mjs
+++ b/generate-docs.mjs
@@ -76,10 +76,6 @@ const docs = new Generator(import.meta.url, {
     setupPath: path.resolve("docs/src/setup.ts"),
 });
 
-docs.compileScript("main", "./docs/src/main.js", {
-    appendTo: "body",
-});
-
 docs.compileStyle("docs", "./docs/src/docs-theme.scss", {
     appendTo: "head",
 });

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -409,6 +409,11 @@ export class Generator {
                 format: "iife",
             },
         );
+
+        const runtimeUrl = new URL("runtime-internal.mjs", import.meta.url);
+        this.compileScript("runtime", runtimeUrl, {
+            appendTo: "body",
+        });
     }
 
     public compileScript(

--- a/src/runtime/stub.ts
+++ b/src/runtime/stub.ts
@@ -1,0 +1,7 @@
+/* eslint-disable-next-line no-console -- expected to log */
+console.warn(
+    [
+        "Importing `@forsakringskassan/doc-generator/runtime` is deprecated and will be removed in the next major version.",
+        "Runtime scripts are included automatically and do not need an explicit import",
+    ].join("\n"),
+);

--- a/tests/base/build.mts
+++ b/tests/base/build.mts
@@ -37,10 +37,6 @@ const docs = new Generator(import.meta.url, {
     ],
 });
 
-docs.compileScript("main", "./docs/src/main.ts", {
-    appendTo: "body",
-});
-
 docs.compileStyle("main", "./docs/src/main.scss", {
     appendTo: "head",
 });

--- a/tests/base/docs/src/main.ts
+++ b/tests/base/docs/src/main.ts
@@ -1,1 +1,0 @@
-import "@forsakringskassan/docs-generator/runtime";

--- a/tests/minimal/build.mts
+++ b/tests/minimal/build.mts
@@ -15,10 +15,6 @@ const docs = new Generator(import.meta.url, {
     outputFolder,
 });
 
-docs.compileScript("main", "./docs/src/main.ts", {
-    appendTo: "body",
-});
-
 docs.compileStyle("main", "./docs/src/main.scss", {
     appendTo: "head",
 });

--- a/tests/minimal/docs/src/main.ts
+++ b/tests/minimal/docs/src/main.ts
@@ -1,1 +1,0 @@
-import "@forsakringskassan/docs-generator/runtime";


### PR DESCRIPTION
Inkluderar automatiskt de runtime script som behövs. För processors finns det egentligen redan en sån mekanism men alla använder den inte samt att navigeringen (och mycket av Stefans nya kod) kommer alltid att krävas för att det ska fungera.

Idag måste man alltid inkludera denna kodsnutt i sitt byggscript:

```ts
docs.compileScript("main", "./docs/src/main.js", {
    appendTo: "body",
});
```

Och från `docs/src/main.js` måste man ha:

```ts
@import "@forsakringskassan/docs-generator/runtime";
```

Med denna ändringen så importeras den filen automatiskt (under ett annat namn) och ovan blir en stub som varnar i devtools om att den är onödig.

Fördelen är att det blir enklare att sätta upp och underhålla siter.